### PR TITLE
Feature/add words

### DIFF
--- a/lokaord/database/data/lysingarord/fułlur.json
+++ b/lokaord/database/data/lysingarord/fułlur.json
@@ -1,0 +1,71 @@
+{
+	"orð": "fułlur",
+	"flokkur": "lýsingarorð",
+	"frumstig": {
+		"sb": {
+			"et": {
+				"kk": ["fułlur", "fułlan", "fułlum", "fulls"],
+				"kvk": ["fułl", "fułla", "fułlri", "fułlrar"],
+				"hk": ["fullt", "fullt", "fułlu", "fulls"]
+			},
+			"ft": {
+				"kk": ["fułlir", "fułla", "fułlum", "fułlra"],
+				"kvk": ["fułlar", "fułlar", "fułlum", "fułlra"],
+				"hk": ["fułl", "fułl", "fułlum", "fułlra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["fułli", "fułla", "fułla", "fułla"],
+				"kvk": ["fułla", "fułlu", "fułlu", "fułlu"],
+				"hk": ["fułla", "fułla", "fułla", "fułla"]
+			},
+			"ft": {
+				"kk": ["fułlu", "fułlu", "fułlu", "fułlu"],
+				"kvk": ["fułlu", "fułlu", "fułlu", "fułlu"],
+				"hk": ["fułlu", "fułlu", "fułlu", "fułlu"]
+			}
+		}
+	},
+	"miðstig": {
+		"vb": {
+			"et": {
+				"kk": ["fyłlri", "fyłlri", "fyłlri", "fyłlri"],
+				"kvk": ["fyłlri", "fyłlri", "fyłlri", "fyłlri"],
+				"hk": ["fyłlra", "fyłlra", "fyłlra", "fyłlra"]
+			},
+			"ft": {
+				"kk": ["fyłlri", "fyłlri", "fyłlri", "fyłlri"],
+				"kvk": ["fyłlri", "fyłlri", "fyłlri", "fyłlri"],
+				"hk": ["fyłlri", "fyłlri", "fyłlri", "fyłlri"]
+			}
+		}
+	},
+	"efstastig": {
+		"sb": {
+			"et": {
+				"kk": ["fyllstur", "fyllstan", "fyllstum", "fyllsts"],
+				"kvk": ["fyllst", "fyllsta", "fyllstri", "fyllstrar"],
+				"hk": ["fyllst", "fyllst", "fyllstu", "fyllsts"]
+			},
+			"ft": {
+				"kk": ["fyllstir", "fyllsta", "fyllstum", "fyllstra"],
+				"kvk": ["fyllstar", "fyllstar", "fyllstum", "fyllstra"],
+				"hk": ["fyllst", "fyllst", "fyllstum", "fyllstra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["fyllsti", "fyllsta", "fyllsta", "fyllsta"],
+				"kvk": ["fyllsta", "fyllstu", "fyllstu", "fyllstu"],
+				"hk": ["fyllsta", "fyllsta", "fyllsta", "fyllsta"]
+			},
+			"ft": {
+				"kk": ["fyllstu", "fyllstu", "fyllstu", "fyllstu"],
+				"kvk": ["fyllstu", "fyllstu", "fyllstu", "fyllstu"],
+				"hk": ["fyllstu", "fyllstu", "fyllstu", "fyllstu"]
+			}
+		}
+	},
+	"hash": "dce79f3d87bea664a60bfc41fcbb5f15d2c048e69d65a34bbcbb2e3c6b80bea9"
+}

--- a/lokaord/database/data/lysingarord/lagalegur.json
+++ b/lokaord/database/data/lysingarord/lagalegur.json
@@ -1,0 +1,87 @@
+{
+	"orð": "lagalegur",
+	"flokkur": "lýsingarorð",
+	"samsett": [
+		{
+			"mynd": "laga",
+			"samsetning": "eignarfalls",
+			"orð": "lög",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b085113d03044626996891a0af7cf4cff57cb5f238fd965d3da923b34891cdd8"
+		},
+		{
+			"orð": "legur",
+			"flokkur": "lýsingarorð",
+			"ósjálfstætt": true,
+			"hash": "db1a87d49cf232f93b10f3161d509c01a0674c6239c04d97f366f753ec3a3d98"
+		}
+	],
+	"frumstig": {
+		"sb": {
+			"et": {
+				"kk": ["lagalegur", "lagalegan", "lagalegum", "lagalegs"],
+				"kvk": ["lagaleg", "lagalega", "lagalegri", "lagalegrar"],
+				"hk": ["lagalegt", "lagalegt", "lagalegu", "lagalegs"]
+			},
+			"ft": {
+				"kk": ["lagalegir", "lagalega", "lagalegum", "lagalegra"],
+				"kvk": ["lagalegar", "lagalegar", "lagalegum", "lagalegra"],
+				"hk": ["lagaleg", "lagaleg", "lagalegum", "lagalegra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["lagalegi", "lagalega", "lagalega", "lagalega"],
+				"kvk": ["lagalega", "lagalegu", "lagalegu", "lagalegu"],
+				"hk": ["lagalega", "lagalega", "lagalega", "lagalega"]
+			},
+			"ft": {
+				"kk": ["lagalegu", "lagalegu", "lagalegu", "lagalegu"],
+				"kvk": ["lagalegu", "lagalegu", "lagalegu", "lagalegu"],
+				"hk": ["lagalegu", "lagalegu", "lagalegu", "lagalegu"]
+			}
+		}
+	},
+	"miðstig": {
+		"vb": {
+			"et": {
+				"kk": ["lagalegri", "lagalegri", "lagalegri", "lagalegri"],
+				"kvk": ["lagalegri", "lagalegri", "lagalegri", "lagalegri"],
+				"hk": ["lagalegra", "lagalegra", "lagalegra", "lagalegra"]
+			},
+			"ft": {
+				"kk": ["lagalegri", "lagalegri", "lagalegri", "lagalegri"],
+				"kvk": ["lagalegri", "lagalegri", "lagalegri", "lagalegri"],
+				"hk": ["lagalegri", "lagalegri", "lagalegri", "lagalegri"]
+			}
+		}
+	},
+	"efstastig": {
+		"sb": {
+			"et": {
+				"kk": ["lagalegastur", "lagalegastan", "lagalegustum", "lagalegasts"],
+				"kvk": ["lagalegust", "lagalegasta", "lagalegastri", "lagalegastrar"],
+				"hk": ["lagalegast", "lagalegast", "lagalegustu", "lagalegasts"]
+			},
+			"ft": {
+				"kk": ["lagalegastir", "lagalegasta", "lagalegustum", "lagalegastra"],
+				"kvk": ["lagalegastar", "lagalegastar", "lagalegustum", "lagalegastra"],
+				"hk": ["lagalegust", "lagalegust", "lagalegustum", "lagalegastra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["lagalegasti", "lagalegasta", "lagalegasta", "lagalegasta"],
+				"kvk": ["lagalegasta", "lagalegustu", "lagalegustu", "lagalegustu"],
+				"hk": ["lagalegasta", "lagalegasta", "lagalegasta", "lagalegasta"]
+			},
+			"ft": {
+				"kk": ["lagalegustu", "lagalegustu", "lagalegustu", "lagalegustu"],
+				"kvk": ["lagalegustu", "lagalegustu", "lagalegustu", "lagalegustu"],
+				"hk": ["lagalegustu", "lagalegustu", "lagalegustu", "lagalegustu"]
+			}
+		}
+	},
+	"hash": "3d4766951c6a6a0d4bbcb8b48f4c118e533e8335e2977097cb7ac2797bce7619"
+}

--- a/lokaord/database/data/nafnord/at-hk.json
+++ b/lokaord/database/data/nafnord/at-hk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "at",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["at", "at", "ati", "ats"],
+		"mg": ["atið", "atið", "atinu", "atsins"]
+	},
+	"ft": {
+		"ág": ["öt", "öt", "ötum", "ata"],
+		"mg": ["ötin", "ötin", "ötunum", "atanna"]
+	},
+	"hash": "87b24d1d7d210e3945081ef4a829039eb5e0c9f02020e89c532d8e434a761d40"
+}

--- a/lokaord/database/data/nafnord/atkvæði-hk.json
+++ b/lokaord/database/data/nafnord/atkvæði-hk.json
@@ -1,0 +1,30 @@
+{
+	"orð": "atkvæði",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "at",
+			"samsetning": "stofn",
+			"orð": "at",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "87b24d1d7d210e3945081ef4a829039eb5e0c9f02020e89c532d8e434a761d40"
+		},
+		{
+			"orð": "kvæði",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "288361a760a3420a4172498cceff36716c314b0e815fd725bd2138ffec955e1d"
+		}
+	],
+	"et": {
+		"ág": ["atkvæði", "atkvæði", "atkvæði", "atkvæðis"],
+		"mg": ["atkvæðið", "atkvæðið", "atkvæðinu", "atkvæðisins"]
+	},
+	"ft": {
+		"ág": ["atkvæði", "atkvæði", "atkvæðum", "atkvæða"],
+		"mg": ["atkvæðin", "atkvæðin", "atkvæðunum", "atkvæðanna"]
+	},
+	"hash": "85d814a7f259d9a3d7c98ac7168b06af2d44910561c68c3f1b9f094a9803ff2e"
+}

--- a/lokaord/database/data/nafnord/austur-hk.json
+++ b/lokaord/database/data/nafnord/austur-hk.json
@@ -1,0 +1,10 @@
+{
+	"orð": "austur",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["austur", "austur", "austri", "austurs"],
+		"mg": ["austrið", "austrið", "austrinu", "austursins"]
+	},
+	"hash": "86e8879fc97828d54b96a4e828f3b7cabdb0fe0199a6b72571d0387c56a7127a"
+}

--- a/lokaord/database/data/nafnord/bjóðandi-kk.json
+++ b/lokaord/database/data/nafnord/bjóðandi-kk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "bjóðandi",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"et": {
+		"ág": ["bjóðandi", "bjóðanda", "bjóðanda", "bjóðanda"],
+		"mg": ["bjóðandinn", "bjóðandann", "bjóðandanum", "bjóðandans"]
+	},
+	"ft": {
+		"ág": ["bjóðendur", "bjóðendur", "bjóðendum", "bjóðenda"],
+		"mg": ["bjóðendurnir", "bjóðendurna", "bjóðendunum", "bjóðendanna"]
+	},
+	"hash": "1f3a70f1a0ca63f40353f5c08b6558d2a6ffd79e176d4767b6d85caa62851a0e"
+}

--- a/lokaord/database/data/nafnord/borg-kvk.json
+++ b/lokaord/database/data/nafnord/borg-kvk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "borg",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"et": {
+		"ág": ["borg", "borg", "borg", "borgar"],
+		"mg": ["borgin", "borgina", "borginni", "borgarinnar"]
+	},
+	"ft": {
+		"ág": ["borgir", "borgir", "borgum", "borga"],
+		"mg": ["borgirnar", "borgirnar", "borgunum", "borganna"]
+	},
+	"hash": "f19f3ce8af0f39c8188d8efd811c4c8781210c17618cc98ddefb52d0b400f10a"
+}

--- a/lokaord/database/data/nafnord/bréf-hk.json
+++ b/lokaord/database/data/nafnord/bréf-hk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "bréf",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["bréf", "bréf", "bréfi", "bréfs"],
+		"mg": ["bréfið", "bréfið", "bréfinu", "bréfsins"]
+	},
+	"ft": {
+		"ág": ["bréf", "bréf", "bréfum", "bréfa"],
+		"mg": ["bréfin", "bréfin", "bréfunum", "bréfanna"]
+	},
+	"hash": "fbcbc279fc07bb2b65cde1320726c697f1adb3258bc41af8028fd010fd389f3d"
+}

--- a/lokaord/database/data/nafnord/eftirlit-hk.json
+++ b/lokaord/database/data/nafnord/eftirlit-hk.json
@@ -1,0 +1,31 @@
+{
+	"orð": "eftirlit",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "eftir",
+			"samsetning": "stofn",
+			"orð": "eftir",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "1efed85781de54b8146681802a59ee440e382f821da030774d1a24d01e6b2e4a"
+		},
+		{
+			"orð": "lit",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"ósjálfstætt": true,
+			"hash": "c86e2400266e2a65d922181bb379359e0e36deab7754cf8fcfb88f3917f5eac3"
+		}
+	],
+	"et": {
+		"ág": ["eftirlit", "eftirlit", "eftirliti", "eftirlits"],
+		"mg": ["eftirlitið", "eftirlitið", "eftirlitinu", "eftirlitsins"]
+	},
+	"ft": {
+		"ág": ["eftirlit", "eftirlit", "eftirlitum", "eftirlita"],
+		"mg": ["eftirlitin", "eftirlitin", "eftirlitunum", "eftirlitanna"]
+	},
+	"hash": "2af6e29dd8ccf8dc79f5e5295b764ddd2222c942b005895050abafeaabcae93c"
+}

--- a/lokaord/database/data/nafnord/eftirlitsaðili-kk.json
+++ b/lokaord/database/data/nafnord/eftirlitsaðili-kk.json
@@ -1,0 +1,39 @@
+{
+	"orð": "eftirlitsaðili",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"samsett": [
+		{
+			"mynd": "eftir",
+			"samsetning": "stofn",
+			"orð": "eftir",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "1efed85781de54b8146681802a59ee440e382f821da030774d1a24d01e6b2e4a"
+		},
+		{
+			"mynd": "lits",
+			"samsetning": "eignarfalls",
+			"orð": "lit",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"ósjálfstætt": true,
+			"hash": "c86e2400266e2a65d922181bb379359e0e36deab7754cf8fcfb88f3917f5eac3"
+		},
+		{
+			"orð": "aðili",
+			"flokkur": "nafnorð",
+			"kyn": "kk",
+			"hash": "e2849db8a0b299e95711585333f437181da85712b6607e093ce6fc7631c238e9"
+		}
+	],
+	"et": {
+		"ág": ["eftirlitsaðili", "eftirlitsaðila", "eftirlitsaðila", "eftirlitsaðila"],
+		"mg": ["eftirlitsaðilinn", "eftirlitsaðilann", "eftirlitsaðilanum", "eftirlitsaðilans"]
+	},
+	"ft": {
+		"ág": ["eftirlitsaðilar", "eftirlitsaðila", "eftirlitsaðilum", "eftirlitsaðila"],
+		"mg": ["eftirlitsaðilarnir", "eftirlitsaðilana", "eftirlitsaðilunum", "eftirlitsaðilanna"]
+	},
+	"hash": "f6acac7084180bc353a380c5b94ced992831f74cb56be2b007d6798a601e6179"
+}

--- a/lokaord/database/data/nafnord/eftirlitshlutverk-hk.json
+++ b/lokaord/database/data/nafnord/eftirlitshlutverk-hk.json
@@ -1,0 +1,47 @@
+{
+	"orð": "eftirlitshlutverk",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "eftir",
+			"samsetning": "stofn",
+			"orð": "eftir",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "1efed85781de54b8146681802a59ee440e382f821da030774d1a24d01e6b2e4a"
+		},
+		{
+			"mynd": "lits",
+			"samsetning": "eignarfalls",
+			"orð": "lit",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"ósjálfstætt": true,
+			"hash": "c86e2400266e2a65d922181bb379359e0e36deab7754cf8fcfb88f3917f5eac3"
+		},
+		{
+			"mynd": "hlut",
+			"samsetning": "stofn",
+			"orð": "hlutur",
+			"flokkur": "nafnorð",
+			"kyn": "kk",
+			"hash": "477b67c6db103327ac1258c3a1aafdfc52bf9105705dfaa82b4b653063e3f28c"
+		},
+		{
+			"orð": "verk",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "d6d1be1f19de708a946aa89e3da3aa8047c44ed87809d033f28316b314d9b829"
+		}
+	],
+	"et": {
+		"ág": ["eftirlitshlutverk", "eftirlitshlutverk", "eftirlitshlutverki", "eftirlitshlutverks"],
+		"mg": ["eftirlitshlutverkið", "eftirlitshlutverkið", "eftirlitshlutverkinu", "eftirlitshlutverksins"]
+	},
+	"ft": {
+		"ág": ["eftirlitshlutverk", "eftirlitshlutverk", "eftirlitshlutverkum", "eftirlitshlutverka"],
+		"mg": ["eftirlitshlutverkin", "eftirlitshlutverkin", "eftirlitshlutverkunum", "eftirlitshlutverkanna"]
+	},
+	"hash": "bd71f0b446daf50db150c8e04e23b9444000c7b6d0972d77fedc1119e39a7666"
+}

--- a/lokaord/database/data/nafnord/frambjóðandi-kk.json
+++ b/lokaord/database/data/nafnord/frambjóðandi-kk.json
@@ -1,0 +1,30 @@
+{
+	"orð": "frambjóðandi",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"samsett": [
+		{
+			"mynd": "fram",
+			"samsetning": "stofn",
+			"orð": "fram",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "717a2fdecce3aa290b9cb9b01310a79645d4517febbebd5d2c55bcf9c888e158"
+		},
+		{
+			"orð": "bjóðandi",
+			"flokkur": "nafnorð",
+			"kyn": "kk",
+			"hash": "1f3a70f1a0ca63f40353f5c08b6558d2a6ffd79e176d4767b6d85caa62851a0e"
+		}
+	],
+	"et": {
+		"ág": ["frambjóðandi", "frambjóðanda", "frambjóðanda", "frambjóðanda"],
+		"mg": ["frambjóðandinn", "frambjóðandann", "frambjóðandanum", "frambjóðandans"]
+	},
+	"ft": {
+		"ág": ["frambjóðendur", "frambjóðendur", "frambjóðendum", "frambjóðenda"],
+		"mg": ["frambjóðendurnir", "frambjóðendurna", "frambjóðendunum", "frambjóðendanna"]
+	},
+	"hash": "9526bfeebc34f2363b53ce7ba86625895067ecda67b1d21dd5cc498c397974a6"
+}

--- a/lokaord/database/data/nafnord/hlutur-kk.json
+++ b/lokaord/database/data/nafnord/hlutur-kk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "hlutur",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"et": {
+		"ág": ["hlutur", "hlut", "hlut", "hlutar"],
+		"mg": ["hluturinn", "hlutinn", "hlutnum", "hlutarins"]
+	},
+	"ft": {
+		"ág": ["hlutir", "hluti", "hlutum", "hluta"],
+		"mg": ["hlutirnir", "hlutina", "hlutunum", "hlutanna"]
+	},
+	"hash": "477b67c6db103327ac1258c3a1aafdfc52bf9105705dfaa82b4b653063e3f28c"
+}

--- a/lokaord/database/data/nafnord/hlutverk-hk.json
+++ b/lokaord/database/data/nafnord/hlutverk-hk.json
@@ -1,0 +1,30 @@
+{
+	"orð": "hlutverk",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "hlut",
+			"samsetning": "stofn",
+			"orð": "hlutur",
+			"flokkur": "nafnorð",
+			"kyn": "kk",
+			"hash": "477b67c6db103327ac1258c3a1aafdfc52bf9105705dfaa82b4b653063e3f28c"
+		},
+		{
+			"orð": "verk",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "d6d1be1f19de708a946aa89e3da3aa8047c44ed87809d033f28316b314d9b829"
+		}
+	],
+	"et": {
+		"ág": ["hlutverk", "hlutverk", "hlutverki", "hlutverks"],
+		"mg": ["hlutverkið", "hlutverkið", "hlutverkinu", "hlutverksins"]
+	},
+	"ft": {
+		"ág": ["hlutverk", "hlutverk", "hlutverkum", "hlutverka"],
+		"mg": ["hlutverkin", "hlutverkin", "hlutverkunum", "hlutverkanna"]
+	},
+	"hash": "42edb16fee5fb2bda72b8726b35a1f57b7fb95a8cfbd3b7a6354cffac528bc08"
+}

--- a/lokaord/database/data/nafnord/hvíla-kvk.json
+++ b/lokaord/database/data/nafnord/hvíla-kvk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "hvíla",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"et": {
+		"ág": ["hvíla", "hvílu", "hvílu", "hvílu"],
+		"mg": ["hvílan", "hvíluna", "hvílunni", "hvílunnar"]
+	},
+	"ft": {
+		"ág": ["hvílur", "hvílur", "hvílum", "hvílna"],
+		"mg": ["hvílurnar", "hvílurnar", "hvílunum", "hvílnanna"]
+	},
+	"hash": "74e3c5a686bedfa07f06ca0c26830d0bebadd08644155058b8e6a8927e65384a"
+}

--- a/lokaord/database/data/nafnord/hótel-hk.json
+++ b/lokaord/database/data/nafnord/hótel-hk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "hótel",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["hótel", "hótel", "hóteli", "hótels"],
+		"mg": ["hótelið", "hótelið", "hótelinu", "hótelsins"]
+	},
+	"ft": {
+		"ág": ["hótel", "hótel", "hótelum", "hótela"],
+		"mg": ["hótelin", "hótelin", "hótelunum", "hótelanna"]
+	},
+	"hash": "4ce3b74e644718626924dfe87c9fb7e4a14b1df7e1b469f8a32aca1a2cda2fc6"
+}

--- a/lokaord/database/data/nafnord/kjörbréfanefnd-kvk.json
+++ b/lokaord/database/data/nafnord/kjörbréfanefnd-kvk.json
@@ -1,0 +1,39 @@
+{
+	"orð": "kjörbréfanefnd",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"samsett": [
+		{
+			"mynd": "kjör",
+			"samsetning": "stofn",
+			"orð": "kjör",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"merking": "kosning",
+			"hash": "851a58c80b59600df3c79bf82b663dcc868620250960ca31178ab284deb3c83c"
+		},
+		{
+			"mynd": "bréfa",
+			"samsetning": "eignarfalls",
+			"orð": "bréf",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "fbcbc279fc07bb2b65cde1320726c697f1adb3258bc41af8028fd010fd389f3d"
+		},
+		{
+			"orð": "nefnd",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"hash": "bf813dc5a89794234d21a4a3cc4a9b245d7ee684f00fecb69e125f9f170e6fb2"
+		}
+	],
+	"et": {
+		"ág": ["kjörbréfanefnd", "kjörbréfanefnd", "kjörbréfanefnd", "kjörbréfanefndar"],
+		"mg": ["kjörbréfanefndin", "kjörbréfanefndina", "kjörbréfanefndinni", "kjörbréfanefndarinnar"]
+	},
+	"ft": {
+		"ág": ["kjörbréfanefndir", "kjörbréfanefndir", "kjörbréfanefndum", "kjörbréfanefnda"],
+		"mg": ["kjörbréfanefndirnar", "kjörbréfanefndirnar", "kjörbréfanefndunum", "kjörbréfanefndanna"]
+	},
+	"hash": "21210cc9e0e9954d43e8b454d0cfbf617b9d803911de70596cb64a9e6540c9fb"
+}

--- a/lokaord/database/data/nafnord/kjörstjórn-kvk.json
+++ b/lokaord/database/data/nafnord/kjörstjórn-kvk.json
@@ -1,0 +1,31 @@
+{
+	"orð": "kjörstjórn",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"samsett": [
+		{
+			"mynd": "kjör",
+			"samsetning": "stofn",
+			"orð": "kjör",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"merking": "kosning",
+			"hash": "851a58c80b59600df3c79bf82b663dcc868620250960ca31178ab284deb3c83c"
+		},
+		{
+			"orð": "stjórn",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"hash": "7e07a58bb46ffe5f39bfba19fc4c4a353e39bf60e06a73ecdfc33e2bbefe45e1"
+		}
+	],
+	"et": {
+		"ág": ["kjörstjórn", "kjörstjórn", "kjörstjórn", "kjörstjórnar"],
+		"mg": ["kjörstjórnin", "kjörstjórnina", "kjörstjórninni", "kjörstjórnarinnar"]
+	},
+	"ft": {
+		"ág": ["kjörstjórnir", "kjörstjórnir", "kjörstjórnum", "kjörstjórna"],
+		"mg": ["kjörstjórnirnar", "kjörstjórnirnar", "kjörstjórnunum", "kjörstjórnanna"]
+	},
+	"hash": "5233c908302091e5f108d670fc33bcb8cbccaa4038762a2cfda645eed5e2f46d"
+}

--- a/lokaord/database/data/nafnord/koma-kvk.json
+++ b/lokaord/database/data/nafnord/koma-kvk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "koma",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"et": {
+		"ág": ["koma", "komu", "komu", "komu"],
+		"mg": ["koman", "komuna", "komunni", "komunnar"]
+	},
+	"ft": {
+		"ág": ["komur", "komur", "komum", "koma"],
+		"mg": ["komurnar", "komurnar", "komunum", "komanna"]
+	},
+	"hash": "18ea87f499ae07b27d2495d09efdd4502300ab36bcbc382962caf849a29b7577"
+}

--- a/lokaord/database/data/nafnord/kvæði-hk.json
+++ b/lokaord/database/data/nafnord/kvæði-hk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "kvæði",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["kvæði", "kvæði", "kvæði", "kvæðis"],
+		"mg": ["kvæðið", "kvæðið", "kvæðinu", "kvæðisins"]
+	},
+	"ft": {
+		"ág": ["kvæði", "kvæði", "kvæðum", "kvæða"],
+		"mg": ["kvæðin", "kvæðin", "kvæðunum", "kvæðanna"]
+	},
+	"hash": "288361a760a3420a4172498cceff36716c314b0e815fd725bd2138ffec955e1d"
+}

--- a/lokaord/database/data/nafnord/lit-hk-ó.json
+++ b/lokaord/database/data/nafnord/lit-hk-ó.json
@@ -1,0 +1,15 @@
+{
+	"orð": "lit",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["lit", "lit", "liti", "lits"],
+		"mg": ["litið", "litið", "litinu", "litsins"]
+	},
+	"ft": {
+		"ág": ["lit", "lit", "litum", "lita"],
+		"mg": ["litin", "litin", "litunum", "litanna"]
+	},
+	"ósjálfstætt": true,
+	"hash": "c86e2400266e2a65d922181bb379359e0e36deab7754cf8fcfb88f3917f5eac3"
+}

--- a/lokaord/database/data/nafnord/nefnd-kvk.json
+++ b/lokaord/database/data/nafnord/nefnd-kvk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "nefnd",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"et": {
+		"ág": ["nefnd", "nefnd", "nefnd", "nefndar"],
+		"mg": ["nefndin", "nefndina", "nefndinni", "nefndarinnar"]
+	},
+	"ft": {
+		"ág": ["nefndir", "nefndir", "nefndum", "nefnda"],
+		"mg": ["nefndirnar", "nefndirnar", "nefndunum", "nefndanna"]
+	},
+	"hash": "bf813dc5a89794234d21a4a3cc4a9b245d7ee684f00fecb69e125f9f170e6fb2"
+}

--- a/lokaord/database/data/nafnord/nes-hk.json
+++ b/lokaord/database/data/nafnord/nes-hk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "nes",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["nes", "nes", "nesi", "ness"],
+		"mg": ["nesið", "nesið", "nesinu", "nessins"]
+	},
+	"ft": {
+		"ág": ["nes", "nes", "nesjum", "nesja"],
+		"mg": ["nesin", "nesin", "nesjunum", "nesjanna"]
+	},
+	"hash": "53e932759a893822343d75a10538df189dcd58b764d9051b759dd5d0ef01677b"
+}

--- a/lokaord/database/data/nafnord/norðaustur-hk.json
+++ b/lokaord/database/data/nafnord/norðaustur-hk.json
@@ -1,0 +1,26 @@
+{
+	"orð": "norðaustur",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "norð",
+			"samsetning": "stofn",
+			"orð": "norður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b2e5fb6c4e5f889465a961360d917e9bd70b236aa95440e20ba7555cb7215c90"
+		},
+		{
+			"orð": "austur",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "86e8879fc97828d54b96a4e828f3b7cabdb0fe0199a6b72571d0387c56a7127a"
+		}
+	],
+	"et": {
+		"ág": ["norðaustur", "norðaustur", "norðaustri", "norðausturs"],
+		"mg": ["norðaustrið", "norðaustrið", "norðaustrinu", "norðaustursins"]
+	},
+	"hash": "0808bc6ede2f89943942390bfc603051d14667d6934466d69d4c22552c1fbf19"
+}

--- a/lokaord/database/data/nafnord/norður-hk.json
+++ b/lokaord/database/data/nafnord/norður-hk.json
@@ -1,0 +1,10 @@
+{
+	"orð": "norður",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["norður", "norður", "norðri", "norðurs"],
+		"mg": ["norðrið", "norðrið", "norðrinu", "norðursins"]
+	},
+	"hash": "b2e5fb6c4e5f889465a961360d917e9bd70b236aa95440e20ba7555cb7215c90"
+}

--- a/lokaord/database/data/nafnord/norðvestur-hk.json
+++ b/lokaord/database/data/nafnord/norðvestur-hk.json
@@ -1,0 +1,26 @@
+{
+	"orð": "norðvestur",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "norð",
+			"samsetning": "stofn",
+			"orð": "norður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b2e5fb6c4e5f889465a961360d917e9bd70b236aa95440e20ba7555cb7215c90"
+		},
+		{
+			"orð": "vestur",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "f1b905deecda3ed00ccdbde2e95a2373952b0672e82df60567df27011840cf8b"
+		}
+	],
+	"et": {
+		"ág": ["norðvestur", "norðvestur", "norðvestri", "norðvesturs"],
+		"mg": ["norðvestrið", "norðvestrið", "norðvestrinu", "norðvestursins"]
+	},
+	"hash": "abb9e2ed06b54261d28b5ceb14b0253c92bc8a0536c7c7acb0cf737f50da989f"
+}

--- a/lokaord/database/data/nafnord/suðaustur-hk.json
+++ b/lokaord/database/data/nafnord/suðaustur-hk.json
@@ -1,0 +1,26 @@
+{
+	"orð": "suðaustur",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "suð",
+			"samsetning": "stofn",
+			"orð": "suður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "8d80e5d622dbab3685e23cf2d97c6aadb6fb31860418092a4048dd98d1a4b1a2"
+		},
+		{
+			"orð": "austur",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "86e8879fc97828d54b96a4e828f3b7cabdb0fe0199a6b72571d0387c56a7127a"
+		}
+	],
+	"et": {
+		"ág": ["suðaustur", "suðaustur", "suðaustri", "suðausturs"],
+		"mg": ["suðaustrið", "suðaustrið", "suðaustrinu", "suðaustursins"]
+	},
+	"hash": "d932069f35af7b71a9741812223deaac11162360e4f04ab1a0a765ebd29c4b8c"
+}

--- a/lokaord/database/data/nafnord/suður-hk.json
+++ b/lokaord/database/data/nafnord/suður-hk.json
@@ -1,0 +1,10 @@
+{
+	"orð": "suður",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["suður", "suður", "suðri", "suðurs"],
+		"mg": ["suðrið", "suðrið", "suðrinu", "suðursins"]
+	},
+	"hash": "8d80e5d622dbab3685e23cf2d97c6aadb6fb31860418092a4048dd98d1a4b1a2"
+}

--- a/lokaord/database/data/nafnord/suðvestur-hk.json
+++ b/lokaord/database/data/nafnord/suðvestur-hk.json
@@ -1,0 +1,26 @@
+{
+	"orð": "suðvestur",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "suð",
+			"samsetning": "stofn",
+			"orð": "suður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "8d80e5d622dbab3685e23cf2d97c6aadb6fb31860418092a4048dd98d1a4b1a2"
+		},
+		{
+			"orð": "vestur",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "f1b905deecda3ed00ccdbde2e95a2373952b0672e82df60567df27011840cf8b"
+		}
+	],
+	"et": {
+		"ág": ["suðvestur", "suðvestur", "suðvestri", "suðvesturs"],
+		"mg": ["suðvestrið", "suðvestrið", "suðvestrinu", "suðvestursins"]
+	},
+	"hash": "9fbc1b30c3093552a37ff30351bc814535accfe4c2430df11877c0a2eeaa4808"
+}

--- a/lokaord/database/data/nafnord/vestur-hk.json
+++ b/lokaord/database/data/nafnord/vestur-hk.json
@@ -1,0 +1,10 @@
+{
+	"orð": "vestur",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"et": {
+		"ág": ["vestur", "vestur", "vestri", "vesturs"],
+		"mg": ["vestrið", "vestrið", "vestrinu", "vestursins"]
+	},
+	"hash": "f1b905deecda3ed00ccdbde2e95a2373952b0672e82df60567df27011840cf8b"
+}

--- a/lokaord/database/data/nafnord/yfirkjörstjórn-kvk.json
+++ b/lokaord/database/data/nafnord/yfirkjörstjórn-kvk.json
@@ -1,0 +1,39 @@
+{
+	"orð": "yfirkjörstjórn",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"samsett": [
+		{
+			"mynd": "yfir",
+			"samsetning": "stofn",
+			"orð": "yfir",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "79d9acf49315670e17104278529e75d92d0622783f1b8d8e9515af7484ecbb11"
+		},
+		{
+			"mynd": "kjör",
+			"samsetning": "stofn",
+			"orð": "kjör",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"merking": "kosning",
+			"hash": "851a58c80b59600df3c79bf82b663dcc868620250960ca31178ab284deb3c83c"
+		},
+		{
+			"orð": "stjórn",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"hash": "7e07a58bb46ffe5f39bfba19fc4c4a353e39bf60e06a73ecdfc33e2bbefe45e1"
+		}
+	],
+	"et": {
+		"ág": ["yfirkjörstjórn", "yfirkjörstjórn", "yfirkjörstjórn", "yfirkjörstjórnar"],
+		"mg": ["yfirkjörstjórnin", "yfirkjörstjórnina", "yfirkjörstjórninni", "yfirkjörstjórnarinnar"]
+	},
+	"ft": {
+		"ág": ["yfirkjörstjórnir", "yfirkjörstjórnir", "yfirkjörstjórnum", "yfirkjörstjórna"],
+		"mg": ["yfirkjörstjórnirnar", "yfirkjörstjórnirnar", "yfirkjörstjórnunum", "yfirkjörstjórnanna"]
+	},
+	"hash": "2a8d5ee308e6c507d7607d2db0529ac22d96c2c14f6d1626ea93212d733ad8a8"
+}

--- a/lokaord/database/data/sagnord/afturkvæma.json
+++ b/lokaord/database/data/sagnord/afturkvæma.json
@@ -1,0 +1,151 @@
+{
+	"orð": "afturkvæma",
+	"flokkur": "sagnorð",
+	"samsett": [
+		{
+			"mynd": "aftur",
+			"samsetning": "stofn",
+			"orð": "aftur",
+			"flokkur": "smáorð",
+			"undirflokkur": "atviksorð",
+			"hash": "931716b7190287fbd7dde769199730f2170e6aae6fa0810e081f6465d2d376f7"
+		},
+		{
+			"orð": "kvæma",
+			"flokkur": "sagnorð",
+			"ósjálfstætt": true,
+			"hash": "2d67652507f8cc2d179b68ff544f8c99cd863155303104d3cc198f50335bcd95"
+		}
+	],
+	"germynd": {
+		"nafnháttur": "afturkvæma",
+		"sagnbót": "afturkvæmt",
+		"boðháttur": {
+			"stýfður": "afturkvæm",
+			"et": "afturkvæmdu",
+			"ft": "afturkvæmið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["afturkvæmi", "afturkvæmir", "afturkvæmir"],
+					"ft": ["afturkvæmum", "afturkvæmið", "afturkvæma"]
+				},
+				"þátíð": {
+					"et": ["afturkvæmdi", "afturkvæmdir", "afturkvæmdi"],
+					"ft": ["afturkvæmdum", "afturkvæmduð", "afturkvæmdu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["afturkvæmi", "afturkvæmir", "afturkvæmi"],
+					"ft": ["afturkvæmum", "afturkvæmið", "afturkvæmi"]
+				},
+				"þátíð": {
+					"et": ["afturkvæmdi", "afturkvæmdir", "afturkvæmdi"],
+					"ft": ["afturkvæmdum", "afturkvæmduð", "afturkvæmdu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "afturkvæmirðu",
+					"ft": "afturkvæmiði"
+				},
+				"þátíð": {
+					"et": "afturkvæmdirðu",
+					"ft": "afturkvæmduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "afturkvæmirðu",
+					"ft": "afturkvæmiði"
+				},
+				"þátíð": {
+					"et": "afturkvæmdirðu",
+					"ft": "afturkvæmduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "afturkvæmast",
+		"sagnbót": "afturkvæmst",
+		"boðháttur": {
+			"et": "afturkvæmstu",
+			"ft": "afturkvæmist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["afturkvæmist", "afturkvæmist", "afturkvæmist"],
+					"ft": ["afturkvæmumst", "afturkvæmist", "afturkvæmast"]
+				},
+				"þátíð": {
+					"et": ["afturkvæmdist", "afturkvæmdist", "afturkvæmdist"],
+					"ft": ["afturkvæmdumst", "afturkvæmdust", "afturkvæmdust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["afturkvæmist", "afturkvæmist", "afturkvæmist"],
+					"ft": ["afturkvæmumst", "afturkvæmist", "afturkvæmist"]
+				},
+				"þátíð": {
+					"et": ["afturkvæmdist", "afturkvæmdist", "afturkvæmdist"],
+					"ft": ["afturkvæmdumst", "afturkvæmdust", "afturkvæmdust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "afturkvæmistu"
+				},
+				"þátíð": {
+					"et": "afturkvæmdistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "afturkvæmistu"
+				},
+				"þátíð": {
+					"et": "afturkvæmdistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "afturkvæmandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["afturkvæmdur", "afturkvæmdan", "afturkvæmdum", "afturkvæmds"],
+					"kvk": ["afturkvæmd", "afturkvæmda", "afturkvæmdri", "afturkvæmdrar"],
+					"hk": ["afturkvæmt", "afturkvæmt", "afturkvæmdu", "afturkvæmds"]
+				},
+				"ft": {
+					"kk": ["afturkvæmdir", "afturkvæmda", "afturkvæmdum", "afturkvæmdra"],
+					"kvk": ["afturkvæmdar", "afturkvæmdar", "afturkvæmdum", "afturkvæmdra"],
+					"hk": ["afturkvæmd", "afturkvæmd", "afturkvæmdum", "afturkvæmdra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["afturkvæmdi", "afturkvæmda", "afturkvæmda", "afturkvæmda"],
+					"kvk": ["afturkvæmda", "afturkvæmdu", "afturkvæmdu", "afturkvæmdu"],
+					"hk": ["afturkvæmda", "afturkvæmda", "afturkvæmda", "afturkvæmda"]
+				},
+				"ft": {
+					"kk": ["afturkvæmdu", "afturkvæmdu", "afturkvæmdu", "afturkvæmdu"],
+					"kvk": ["afturkvæmdu", "afturkvæmdu", "afturkvæmdu", "afturkvæmdu"],
+					"hk": ["afturkvæmdu", "afturkvæmdu", "afturkvæmdu", "afturkvæmdu"]
+				}
+			}
+		}
+	},
+	"hash": "28e0e323fa833192aec38cbd551dfb03fd945377a9fa86f70e3c3358d1d1ce63"
+}

--- a/lokaord/database/data/sagnord/bera.json
+++ b/lokaord/database/data/sagnord/bera.json
@@ -1,0 +1,158 @@
+{
+	"orð": "bera",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "bera",
+		"sagnbót": "borið",
+		"boðháttur": {
+			"stýfður": "ber",
+			"et": "berðu",
+			"ft": "berið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["ber", "berð", "ber"],
+					"ft": ["berum", "berið", "bera"]
+				},
+				"þátíð": {
+					"et": ["bar", "barst", "bar"],
+					"ft": ["bárum", "báruð", "báru"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["beri", "berir", "beri"],
+					"ft": ["berum", "berið", "beri"]
+				},
+				"þátíð": {
+					"et": ["bæri", "bærir", "bæri"],
+					"ft": ["bærum", "bæruð", "bæru"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "berðu",
+					"ft": "beriði"
+				},
+				"þátíð": {
+					"et": "barstu",
+					"ft": "báruði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "berirðu",
+					"ft": "beriði"
+				},
+				"þátíð": {
+					"et": "bærirðu",
+					"ft": "bæruði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "berast",
+		"sagnbót": "berist",
+		"boðháttur": {
+			"et": "berstu",
+			"ft": "berist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["berst", "berst", "berst"],
+					"ft": ["berumst", "berist", "berast"]
+				},
+				"þátíð": {
+					"et": ["barst", "barst", "barst"],
+					"ft": ["bárumst", "bárust", "bárust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["berist", "berist", "berist"],
+					"ft": ["berumst", "berist", "berist"]
+				},
+				"þátíð": {
+					"et": ["bærist", "bærist", "bærist"],
+					"ft": ["bærumst", "bærust", "bærust"]
+				}
+			}
+		},
+		"ópersónuleg": {
+			"frumlag": "þágufall",
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["berst", "berst", "berst"],
+					"ft": ["berst", "berst", "berst"]
+				},
+				"þátíð": {
+					"et": ["barst", "barst", "barst"],
+					"ft": ["barst", "barst", "barst"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["berist", "berist", "berist"],
+					"ft": ["berist", "berist", "berist"]
+				},
+				"þátíð": {
+					"et": ["bærist", "bærist", "bærist"],
+					"ft": ["bærist", "bærist", "bærist"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "berstu"
+				},
+				"þátíð": {
+					"et": "barstu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "beristu"
+				},
+				"þátíð": {
+					"et": "bæristu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "berandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["borinn", "borinn", "bornum", "borins"],
+					"kvk": ["borin", "borna", "borinni", "borinnar"],
+					"hk": ["borið", "borið", "bornu", "borins"]
+				},
+				"ft": {
+					"kk": ["bornir", "borna", "bornum", "borinna"],
+					"kvk": ["bornar", "bornar", "bornum", "borinna"],
+					"hk": ["borin", "borin", "bornum", "borinna"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["borni", "borna", "borna", "borna"],
+					"kvk": ["borna", "bornu", "bornu", "bornu"],
+					"hk": ["borna", "borna", "borna", "borna"]
+				},
+				"ft": {
+					"kk": ["bornu", "bornu", "bornu", "bornu"],
+					"kvk": ["bornu", "bornu", "bornu", "bornu"],
+					"hk": ["bornu", "bornu", "bornu", "bornu"]
+				}
+			}
+		}
+	},
+	"hash": "0e297e5183460155f383bd26ddc235cffac8408c8000432a1b8beebbaf7b97d2"
+}

--- a/lokaord/database/data/sagnord/fara.json
+++ b/lokaord/database/data/sagnord/fara.json
@@ -1,0 +1,158 @@
+{
+	"orð": "fara",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "fara",
+		"sagnbót": "farið",
+		"boðháttur": {
+			"stýfður": "far",
+			"et": "farðu",
+			"ft": "farið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["fer", "ferð", "fer"],
+					"ft": ["förum", "farið", "fara"]
+				},
+				"þátíð": {
+					"et": ["fór", "fórst", "fór"],
+					"ft": ["fórum", "fóruð", "fóru"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["fari", "farir", "fari"],
+					"ft": ["förum", "farið", "fari"]
+				},
+				"þátíð": {
+					"et": ["færi", "færir", "færi"],
+					"ft": ["færum", "færuð", "færu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "ferðu",
+					"ft": "fariði"
+				},
+				"þátíð": {
+					"et": "fórstu",
+					"ft": "fóruði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "farirðu",
+					"ft": "fariði"
+				},
+				"þátíð": {
+					"et": "færirðu",
+					"ft": "færuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "farast",
+		"sagnbót": "farist",
+		"boðháttur": {
+			"et": "farstu",
+			"ft": "farist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["ferst", "ferst", "ferst"],
+					"ft": ["förumst", "farist", "farast"]
+				},
+				"þátíð": {
+					"et": ["fórst", "fórst", "fórst"],
+					"ft": ["fórumst", "fórust", "fórust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["farist", "farist", "farist"],
+					"ft": ["förumst", "farist", "farist"]
+				},
+				"þátíð": {
+					"et": ["færist", "færist", "færist"],
+					"ft": ["færumst", "færust", "færust"]
+				}
+			}
+		},
+		"ópersónuleg": {
+			"frumlag": "þágufall",
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["ferst", "ferst", "ferst"],
+					"ft": ["ferst", "ferst", "ferst"]
+				},
+				"þátíð": {
+					"et": ["fórst", "fórst", "fórst"],
+					"ft": ["fórst", "fórst", "fórst"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["farist", "farist", "farist"],
+					"ft": ["farist", "farist", "farist"]
+				},
+				"þátíð": {
+					"et": ["færist", "færist", "færist"],
+					"ft": ["færist", "færist", "færist"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "ferstu"
+				},
+				"þátíð": {
+					"et": "fórstu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "faristu"
+				},
+				"þátíð": {
+					"et": "færistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "farandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["farinn", "farinn", "förnum", "farins"],
+					"kvk": ["farin", "farna", "farinni", "farinnar"],
+					"hk": ["farið", "farið", "förnu", "farins"]
+				},
+				"ft": {
+					"kk": ["farnir", "farna", "förnum", "farinna"],
+					"kvk": ["farnar", "farnar", "förnum", "farinna"],
+					"hk": ["farin", "farin", "förnum", "farinna"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["farni", "farna", "farna", "farna"],
+					"kvk": ["farna", "förnu", "förnu", "förnu"],
+					"hk": ["farna", "farna", "farna", "farna"]
+				},
+				"ft": {
+					"kk": ["förnu", "förnu", "förnu", "förnu"],
+					"kvk": ["förnu", "förnu", "förnu", "förnu"],
+					"hk": ["förnu", "förnu", "förnu", "förnu"]
+				}
+			}
+		}
+	},
+	"hash": "7fa934a72557f769dc9426b8b341ade149a680fed23f025f5357323e647cf146"
+}

--- a/lokaord/database/data/sagnord/framkvæma.json
+++ b/lokaord/database/data/sagnord/framkvæma.json
@@ -1,0 +1,151 @@
+{
+	"orð": "framkvæma",
+	"flokkur": "sagnorð",
+	"samsett": [
+		{
+			"mynd": "fram",
+			"samsetning": "stofn",
+			"orð": "fram",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "717a2fdecce3aa290b9cb9b01310a79645d4517febbebd5d2c55bcf9c888e158"
+		},
+		{
+			"orð": "kvæma",
+			"flokkur": "sagnorð",
+			"ósjálfstætt": true,
+			"hash": "2d67652507f8cc2d179b68ff544f8c99cd863155303104d3cc198f50335bcd95"
+		}
+	],
+	"germynd": {
+		"nafnháttur": "framkvæma",
+		"sagnbót": "framkvæmt",
+		"boðháttur": {
+			"stýfður": "framkvæm",
+			"et": "framkvæmdu",
+			"ft": "framkvæmið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["framkvæmi", "framkvæmir", "framkvæmir"],
+					"ft": ["framkvæmum", "framkvæmið", "framkvæma"]
+				},
+				"þátíð": {
+					"et": ["framkvæmdi", "framkvæmdir", "framkvæmdi"],
+					"ft": ["framkvæmdum", "framkvæmduð", "framkvæmdu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["framkvæmi", "framkvæmir", "framkvæmi"],
+					"ft": ["framkvæmum", "framkvæmið", "framkvæmi"]
+				},
+				"þátíð": {
+					"et": ["framkvæmdi", "framkvæmdir", "framkvæmdi"],
+					"ft": ["framkvæmdum", "framkvæmduð", "framkvæmdu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "framkvæmirðu",
+					"ft": "framkvæmiði"
+				},
+				"þátíð": {
+					"et": "framkvæmdirðu",
+					"ft": "framkvæmduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "framkvæmirðu",
+					"ft": "framkvæmiði"
+				},
+				"þátíð": {
+					"et": "framkvæmdirðu",
+					"ft": "framkvæmduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "framkvæmast",
+		"sagnbót": "framkvæmst",
+		"boðháttur": {
+			"et": "framkvæmstu",
+			"ft": "framkvæmist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["framkvæmist", "framkvæmist", "framkvæmist"],
+					"ft": ["framkvæmumst", "framkvæmist", "framkvæmast"]
+				},
+				"þátíð": {
+					"et": ["framkvæmdist", "framkvæmdist", "framkvæmdist"],
+					"ft": ["framkvæmdumst", "framkvæmdust", "framkvæmdust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["framkvæmist", "framkvæmist", "framkvæmist"],
+					"ft": ["framkvæmumst", "framkvæmist", "framkvæmist"]
+				},
+				"þátíð": {
+					"et": ["framkvæmdist", "framkvæmdist", "framkvæmdist"],
+					"ft": ["framkvæmdumst", "framkvæmdust", "framkvæmdust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "framkvæmistu"
+				},
+				"þátíð": {
+					"et": "framkvæmdistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "framkvæmistu"
+				},
+				"þátíð": {
+					"et": "framkvæmdistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "framkvæmandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["framkvæmdur", "framkvæmdan", "framkvæmdum", "framkvæmds"],
+					"kvk": ["framkvæmd", "framkvæmda", "framkvæmdri", "framkvæmdrar"],
+					"hk": ["framkvæmt", "framkvæmt", "framkvæmdu", "framkvæmds"]
+				},
+				"ft": {
+					"kk": ["framkvæmdir", "framkvæmda", "framkvæmdum", "framkvæmdra"],
+					"kvk": ["framkvæmdar", "framkvæmdar", "framkvæmdum", "framkvæmdra"],
+					"hk": ["framkvæmd", "framkvæmd", "framkvæmdum", "framkvæmdra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["framkvæmdi", "framkvæmda", "framkvæmda", "framkvæmda"],
+					"kvk": ["framkvæmda", "framkvæmdu", "framkvæmdu", "framkvæmdu"],
+					"hk": ["framkvæmda", "framkvæmda", "framkvæmda", "framkvæmda"]
+				},
+				"ft": {
+					"kk": ["framkvæmdu", "framkvæmdu", "framkvæmdu", "framkvæmdu"],
+					"kvk": ["framkvæmdu", "framkvæmdu", "framkvæmdu", "framkvæmdu"],
+					"hk": ["framkvæmdu", "framkvæmdu", "framkvæmdu", "framkvæmdu"]
+				}
+			}
+		}
+	},
+	"hash": "67c761305e4d1a26831b85a4eec5458a81daebc0153e0c25c95620054ba431a4"
+}

--- a/lokaord/database/data/sagnord/hafa.json
+++ b/lokaord/database/data/sagnord/hafa.json
@@ -1,0 +1,119 @@
+{
+	"orð": "hafa",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "hafa",
+		"sagnbót": "haft",
+		"boðháttur": {
+			"stýfður": "haf",
+			"et": "hafðu",
+			"ft": "hafið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["hef", "hefur", "hefur"],
+					"ft": ["höfum", "hafið", "hafa"]
+				},
+				"þátíð": {
+					"et": ["hafði", "hafðir", "hafði"],
+					"ft": ["höfðum", "höfðuð", "höfðu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["hafi", "hafir", "hafi"],
+					"ft": ["höfum", "hafið", "hafi"]
+				},
+				"þátíð": {
+					"et": ["hefði", "hefðir", "hefði"],
+					"ft": ["hefðum", "hefðuð", "hefðu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "hefurðu",
+					"ft": "hafiði"
+				},
+				"þátíð": {
+					"et": "hafðirðu",
+					"ft": "höfðuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "hafirðu",
+					"ft": "hafiði"
+				},
+				"þátíð": {
+					"et": "hefðirðu",
+					"ft": "hefðuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "hafast",
+		"sagnbót": "hafst",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["hefst", "hefst", "hefst"],
+					"ft": ["höfumst", "hafist", "hafast"]
+				},
+				"þátíð": {
+					"et": ["hafðist", "hafðist", "hafðist"],
+					"ft": ["höfðumst", "höfðust", "höfðust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["hafist", "hafist", "hafist"],
+					"ft": ["höfumst", "hafist", "hafist"]
+				},
+				"þátíð": {
+					"et": ["hefðist", "hefðist", "hefðist"],
+					"ft": ["hefðumst", "hefðust", "hefðust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "hefstu"
+				},
+				"þátíð": {
+					"et": "hafðistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "hafistu"
+				},
+				"þátíð": {
+					"et": "hefðistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "hafandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["hafður", "hafðan", "höfðum", "hafðs"],
+					"kvk": ["höfð", "hafða", "hafðri", "hafðrar"],
+					"hk": ["haft", "haft", "höfðu", "hafðs"]
+				},
+				"ft": {
+					"kk": ["hafðir", "hafða", "höfðum", "hafðra"],
+					"kvk": ["hafðar", "hafðar", "höfðum", "hafðra"],
+					"hk": ["höfð", "höfð", "höfðum", "hafðra"]
+				}
+			}
+		}
+	},
+	"hash": "4372e37471e3ef53deddacab0b23e2073a1972a185db0b6a80701329b832ddcc"
+}

--- a/lokaord/database/data/sagnord/hvíla.json
+++ b/lokaord/database/data/sagnord/hvíla.json
@@ -1,0 +1,135 @@
+{
+	"orð": "hvíla",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "hvíla",
+		"sagnbót": "hvílt",
+		"boðháttur": {
+			"stýfður": "hvíl",
+			"et": "hvíldu",
+			"ft": "hvílið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["hvíli", "hvílir", "hvílir"],
+					"ft": ["hvílum", "hvílið", "hvíla"]
+				},
+				"þátíð": {
+					"et": ["hvíldi", "hvíldir", "hvíldi"],
+					"ft": ["hvíldum", "hvílduð", "hvíldu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["hvíli", "hvílir", "hvíli"],
+					"ft": ["hvílum", "hvílið", "hvíli"]
+				},
+				"þátíð": {
+					"et": ["hvíldi", "hvíldir", "hvíldi"],
+					"ft": ["hvíldum", "hvílduð", "hvíldu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "hvílirðu",
+					"ft": "hvíliði"
+				},
+				"þátíð": {
+					"et": "hvíldirðu",
+					"ft": "hvílduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "hvílirðu",
+					"ft": "hvíliði"
+				},
+				"þátíð": {
+					"et": "hvíldirðu",
+					"ft": "hvílduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "hvílast",
+		"sagnbót": "hvílst",
+		"boðháttur": {
+			"et": "hvílstu",
+			"ft": "hvílist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["hvílist", "hvílist", "hvílist"],
+					"ft": ["hvílumst", "hvílist", "hvílast"]
+				},
+				"þátíð": {
+					"et": ["hvíldist", "hvíldist", "hvíldist"],
+					"ft": ["hvíldumst", "hvíldust", "hvíldust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["hvílist", "hvílist", "hvílist"],
+					"ft": ["hvílumst", "hvílist", "hvílist"]
+				},
+				"þátíð": {
+					"et": ["hvíldist", "hvíldist", "hvíldist"],
+					"ft": ["hvíldumst", "hvíldust", "hvíldust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "hvílistu"
+				},
+				"þátíð": {
+					"et": "hvíldistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "hvílistu"
+				},
+				"þátíð": {
+					"et": "hvíldistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "hvílandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["hvíldur", "hvíldan", "hvíldum", "hvílds"],
+					"kvk": ["hvíld", "hvílda", "hvíldri", "hvíldrar"],
+					"hk": ["hvílt", "hvílt", "hvíldu", "hvílds"]
+				},
+				"ft": {
+					"kk": ["hvíldir", "hvílda", "hvíldum", "hvíldra"],
+					"kvk": ["hvíldar", "hvíldar", "hvíldum", "hvíldra"],
+					"hk": ["hvíld", "hvíld", "hvíldum", "hvíldra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["hvíldi", "hvílda", "hvílda", "hvílda"],
+					"kvk": ["hvílda", "hvíldu", "hvíldu", "hvíldu"],
+					"hk": ["hvílda", "hvílda", "hvílda", "hvílda"]
+				},
+				"ft": {
+					"kk": ["hvíldu", "hvíldu", "hvíldu", "hvíldu"],
+					"kvk": ["hvíldu", "hvíldu", "hvíldu", "hvíldu"],
+					"hk": ["hvíldu", "hvíldu", "hvíldu", "hvíldu"]
+				}
+			}
+		}
+	},
+	"hash": "64bedd8e10892f5f3af52cf8e3d2d744160011180716a098fa234f143f925e5c"
+}

--- a/lokaord/database/data/sagnord/kałla.json
+++ b/lokaord/database/data/sagnord/kałla.json
@@ -1,0 +1,131 @@
+{
+	"orð": "kałla",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "kałla",
+		"sagnbót": "farið",
+		"boðháttur": {
+			"stýfður": "kałla",
+			"et": "kałlaðu",
+			"ft": "kałlið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["kałla", "kałlar", "kałlar"],
+					"ft": ["köłlum", "kałlið", "kałla"]
+				},
+				"þátíð": {
+					"et": ["kałlaði", "kałlaðir", "kałlaði"],
+					"ft": ["köłluðum", "köłluðuð", "köłluðu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["kałli", "kałlir", "kałli"],
+					"ft": ["köłlum", "kałlið", "kałli"]
+				},
+				"þátíð": {
+					"et": ["kałlaði", "kałlaðir", "kałlaði"],
+					"ft": ["köłluðum", "köłluðuð", "köłluðu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "kałlarðu",
+					"ft": "kałliði"
+				},
+				"þátíð": {
+					"et": "kałlaðirðu",
+					"ft": "köłluðuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "kałlirðu",
+					"ft": "kałliði"
+				},
+				"þátíð": {
+					"et": "kałlaðirðu",
+					"ft": "köłluðuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "kałlast",
+		"sagnbót": "kałlast",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["kałlast", "kałlast", "kałlast"],
+					"ft": ["köłlumst", "kałlist", "kałlast"]
+				},
+				"þátíð": {
+					"et": ["kałlaðist", "kałlaðist", "kałlaðist"],
+					"ft": ["köłluðumst", "köłluðust", "köłluðust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["kałlist", "kałlist", "kałlist"],
+					"ft": ["köłlumst", "kałlist", "kałlist"]
+				},
+				"þátíð": {
+					"et": ["kałlaðist", "kałlaðist", "kałlaðist"],
+					"ft": ["köłluðumst", "köłluðust", "köłluðust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "kałlastu"
+				},
+				"þátíð": {
+					"et": "kałlaðistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "kałlistu"
+				},
+				"þátíð": {
+					"et": "kałlaðistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "kałlandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["kałlaður", "kałlaðan", "köłluðum", "kałlaðs"],
+					"kvk": ["köłluð", "kałlaða", "kałlaðri", "kałlaðrar"],
+					"hk": ["kałlað", "kałlað", "köłluðu", "kałlaðs"]
+				},
+				"ft": {
+					"kk": ["kałlaðir", "kałlaða", "köłluðum", "kałlaðra"],
+					"kvk": ["kałlaðar", "kałlaðar", "köłluðum", "kałlaðra"],
+					"hk": ["köłluð", "köłluð", "köłluðum", "kałlaðra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["kałlaði", "kałlaða", "kałlaða", "kałlaða"],
+					"kvk": ["kałlaða", "köłluðu", "köłluðu", "köłluðu"],
+					"hk": ["kałlaða", "kałlaða", "kałlaða", "kałlaða"]
+				},
+				"ft": {
+					"kk": ["köłluðu", "köłluðu", "köłluðu", "köłluðu"],
+					"kvk": ["köłluðu", "köłluðu", "köłluðu", "köłluðu"],
+					"hk": ["köłluðu", "köłluðu", "köłluðu", "köłluðu"]
+				}
+			}
+		}
+	},
+	"hash": "62ce79f3500337e481735aca4d34f4712421d7996325e15df7dc24ddb38fb531"
+}

--- a/lokaord/database/data/sagnord/koma.json
+++ b/lokaord/database/data/sagnord/koma.json
@@ -1,0 +1,131 @@
+{
+	"orð": "koma",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "koma",
+		"sagnbót": "komið",
+		"boðháttur": {
+			"stýfður": "kom",
+			"et": "komdu",
+			"ft": "komið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["kem", "kemur", "kemur"],
+					"ft": ["komum", "komið", "koma"]
+				},
+				"þátíð": {
+					"et": ["kom", "komst", "kom"],
+					"ft": ["komum", "komuð", "komu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["komi", "komir", "komi"],
+					"ft": ["komum", "komið", "komi"]
+				},
+				"þátíð": {
+					"et": ["kæmi", "kæmir", "kæmi"],
+					"ft": ["kæmum", "kæmuð", "kæmu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "kemurðu",
+					"ft": "komiði"
+				},
+				"þátíð": {
+					"et": "komstu",
+					"ft": "komuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "komirðu",
+					"ft": "komiði"
+				},
+				"þátíð": {
+					"et": "kæmirðu",
+					"ft": "kæmuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "komast",
+		"sagnbót": "komist",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["kemst", "kemst", "kemst"],
+					"ft": ["komumst", "komist", "komast"]
+				},
+				"þátíð": {
+					"et": ["komst", "komst", "komst"],
+					"ft": ["komumst", "komust", "komust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["komist", "komist", "komist"],
+					"ft": ["komumst", "komist", "komist"]
+				},
+				"þátíð": {
+					"et": ["kæmist", "kæmist", "kæmist"],
+					"ft": ["kæmumst", "kæmust", "kæmust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "kemstu"
+				},
+				"þátíð": {
+					"et": "komstu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "komistu"
+				},
+				"þátíð": {
+					"et": "kæmistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "komandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["kominn", "kominn", "komnum", "komins"],
+					"kvk": ["komin", "komna", "kominni", "kominnar"],
+					"hk": ["komið", "komið", "komnu", "komins"]
+				},
+				"ft": {
+					"kk": ["komnir", "komna", "komnum", "kominna"],
+					"kvk": ["komnar", "komnar", "komnum", "kominna"],
+					"hk": ["komin", "komin", "komnum", "kominna"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["komni", "komna", "komna", "komna"],
+					"kvk": ["komna", "komnu", "komnu", "komnu"],
+					"hk": ["komna", "komna", "komna", "komna"]
+				},
+				"ft": {
+					"kk": ["komnu", "komnu", "komnu", "komnu"],
+					"kvk": ["komnu", "komnu", "komnu", "komnu"],
+					"hk": ["komnu", "komnu", "komnu", "komnu"]
+				}
+			}
+		}
+	},
+	"hash": "ad011e3f5a9ce16138a8d3ad50c53a2524e679959d74bd54e42d2c39e26c3a51"
+}

--- a/lokaord/database/data/sagnord/kvæma-ó.json
+++ b/lokaord/database/data/sagnord/kvæma-ó.json
@@ -1,0 +1,136 @@
+{
+	"orð": "kvæma",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "kvæma",
+		"sagnbót": "kvæmt",
+		"boðháttur": {
+			"stýfður": "kvæm",
+			"et": "kvæmdu",
+			"ft": "kvæmið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["kvæmi", "kvæmir", "kvæmir"],
+					"ft": ["kvæmum", "kvæmið", "kvæma"]
+				},
+				"þátíð": {
+					"et": ["kvæmdi", "kvæmdir", "kvæmdi"],
+					"ft": ["kvæmdum", "kvæmduð", "kvæmdu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["kvæmi", "kvæmir", "kvæmi"],
+					"ft": ["kvæmum", "kvæmið", "kvæmi"]
+				},
+				"þátíð": {
+					"et": ["kvæmdi", "kvæmdir", "kvæmdi"],
+					"ft": ["kvæmdum", "kvæmduð", "kvæmdu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "kvæmirðu",
+					"ft": "kvæmiði"
+				},
+				"þátíð": {
+					"et": "kvæmdirðu",
+					"ft": "kvæmduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "kvæmirðu",
+					"ft": "kvæmiði"
+				},
+				"þátíð": {
+					"et": "kvæmdirðu",
+					"ft": "kvæmduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "kvæmast",
+		"sagnbót": "kvæmst",
+		"boðháttur": {
+			"et": "kvæmstu",
+			"ft": "kvæmist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["kvæmist", "kvæmist", "kvæmist"],
+					"ft": ["kvæmumst", "kvæmist", "kvæmast"]
+				},
+				"þátíð": {
+					"et": ["kvæmdist", "kvæmdist", "kvæmdist"],
+					"ft": ["kvæmdumst", "kvæmdust", "kvæmdust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["kvæmist", "kvæmist", "kvæmist"],
+					"ft": ["kvæmumst", "kvæmist", "kvæmist"]
+				},
+				"þátíð": {
+					"et": ["kvæmdist", "kvæmdist", "kvæmdist"],
+					"ft": ["kvæmdumst", "kvæmdust", "kvæmdust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "kvæmistu"
+				},
+				"þátíð": {
+					"et": "kvæmdistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "kvæmistu"
+				},
+				"þátíð": {
+					"et": "kvæmdistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "kvæmandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["kvæmdur", "kvæmdan", "kvæmdum", "kvæmds"],
+					"kvk": ["kvæmd", "kvæmda", "kvæmdri", "kvæmdrar"],
+					"hk": ["kvæmt", "kvæmt", "kvæmdu", "kvæmds"]
+				},
+				"ft": {
+					"kk": ["kvæmdir", "kvæmda", "kvæmdum", "kvæmdra"],
+					"kvk": ["kvæmdar", "kvæmdar", "kvæmdum", "kvæmdra"],
+					"hk": ["kvæmd", "kvæmd", "kvæmdum", "kvæmdra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["kvæmdi", "kvæmda", "kvæmda", "kvæmda"],
+					"kvk": ["kvæmda", "kvæmdu", "kvæmdu", "kvæmdu"],
+					"hk": ["kvæmda", "kvæmda", "kvæmda", "kvæmda"]
+				},
+				"ft": {
+					"kk": ["kvæmdu", "kvæmdu", "kvæmdu", "kvæmdu"],
+					"kvk": ["kvæmdu", "kvæmdu", "kvæmdu", "kvæmdu"],
+					"hk": ["kvæmdu", "kvæmdu", "kvæmdu", "kvæmdu"]
+				}
+			}
+		}
+	},
+	"ósjálfstætt": true,
+	"hash": "2d67652507f8cc2d179b68ff544f8c99cd863155303104d3cc198f50335bcd95"
+}

--- a/lokaord/database/data/sagnord/misfara.json
+++ b/lokaord/database/data/sagnord/misfara.json
@@ -1,0 +1,173 @@
+{
+	"orð": "misfara",
+	"flokkur": "sagnorð",
+	"samsett": [
+		{
+			"mynd": "mis",
+			"samsetning": "stofn",
+			"orð": "mis",
+			"flokkur": "smáorð",
+			"undirflokkur": "atviksorð",
+			"hash": "9f316137de59e14bd826323e57541b07ed4118eb2fb9f8cb1909385261b34f95"
+		},
+		{
+			"orð": "fara",
+			"flokkur": "sagnorð",
+			"hash": "7fa934a72557f769dc9426b8b341ade149a680fed23f025f5357323e647cf146"
+		}
+	],
+	"germynd": {
+		"nafnháttur": "misfara",
+		"sagnbót": "misfarið",
+		"boðháttur": {
+			"stýfður": "misfar",
+			"et": "misfarðu",
+			"ft": "misfarið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["misfer", "misferð", "misfer"],
+					"ft": ["misförum", "misfarið", "misfara"]
+				},
+				"þátíð": {
+					"et": ["misfór", "misfórst", "misfór"],
+					"ft": ["misfórum", "misfóruð", "misfóru"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["misfari", "misfarir", "misfari"],
+					"ft": ["misförum", "misfarið", "misfari"]
+				},
+				"þátíð": {
+					"et": ["misfæri", "misfærir", "misfæri"],
+					"ft": ["misfærum", "misfæruð", "misfæru"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "misferðu",
+					"ft": "misfariði"
+				},
+				"þátíð": {
+					"et": "misfórstu",
+					"ft": "misfóruði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "misfarirðu",
+					"ft": "misfariði"
+				},
+				"þátíð": {
+					"et": "misfærirðu",
+					"ft": "misfæruði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "misfarast",
+		"sagnbót": "misfarist",
+		"boðháttur": {
+			"et": "misfarstu",
+			"ft": "misfarist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["misferst", "misferst", "misferst"],
+					"ft": ["misförumst", "misfarist", "misfarast"]
+				},
+				"þátíð": {
+					"et": ["misfórst", "misfórst", "misfórst"],
+					"ft": ["misfórumst", "misfórust", "misfórust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["misfarist", "misfarist", "misfarist"],
+					"ft": ["misförumst", "misfarist", "misfarist"]
+				},
+				"þátíð": {
+					"et": ["misfærist", "misfærist", "misfærist"],
+					"ft": ["misfærumst", "misfærust", "misfærust"]
+				}
+			}
+		},
+		"ópersónuleg": {
+			"frumlag": "þágufall",
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["misferst", "misferst", "misferst"],
+					"ft": ["misferst", "misferst", "misferst"]
+				},
+				"þátíð": {
+					"et": ["misfórst", "misfórst", "misfórst"],
+					"ft": ["misfórst", "misfórst", "misfórst"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["misfarist", "misfarist", "misfarist"],
+					"ft": ["misfarist", "misfarist", "misfarist"]
+				},
+				"þátíð": {
+					"et": ["misfærist", "misfærist", "misfærist"],
+					"ft": ["misfærist", "misfærist", "misfærist"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "misferstu"
+				},
+				"þátíð": {
+					"et": "misfórstu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "misfaristu"
+				},
+				"þátíð": {
+					"et": "misfæristu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "misfarandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["misfarinn", "misfarinn", "misförnum", "misfarins"],
+					"kvk": ["misfarin", "misfarna", "misfarinni", "misfarinnar"],
+					"hk": ["misfarið", "misfarið", "misförnu", "misfarins"]
+				},
+				"ft": {
+					"kk": ["misfarnir", "misfarna", "misförnum", "misfarinna"],
+					"kvk": ["misfarnar", "misfarnar", "misförnum", "misfarinna"],
+					"hk": ["misfarin", "misfarin", "misförnum", "misfarinna"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["misfarni", "misfarna", "misfarna", "misfarna"],
+					"kvk": ["misfarna", "misförnu", "misförnu", "misförnu"],
+					"hk": ["misfarna", "misfarna", "misfarna", "misfarna"]
+				},
+				"ft": {
+					"kk": ["misförnu", "misförnu", "misförnu", "misförnu"],
+					"kvk": ["misförnu", "misförnu", "misförnu", "misförnu"],
+					"hk": ["misförnu", "misförnu", "misförnu", "misförnu"]
+				}
+			}
+		}
+	},
+	"hash": "024b54d55a1f47518b32d22ea4edf8538bea24fff2b21935451e81128bae01b4"
+}

--- a/lokaord/database/data/sagnord/mæta.json
+++ b/lokaord/database/data/sagnord/mæta.json
@@ -1,0 +1,131 @@
+{
+	"orð": "mæta",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "mæta",
+		"sagnbót": "mætt",
+		"boðháttur": {
+			"stýfður": "mæt",
+			"et": "mættu",
+			"ft": "mætið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mæti", "mætir", "mætir"],
+					"ft": ["mætum", "mætið", "mæta"]
+				},
+				"þátíð": {
+					"et": ["mætti", "mættir", "mætti"],
+					"ft": ["mættum", "mættuð", "mættu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mæti", "mætir", "mæti"],
+					"ft": ["mætum", "mætið", "mæti"]
+				},
+				"þátíð": {
+					"et": ["mætti", "mættir", "mætti"],
+					"ft": ["mættum", "mættuð", "mættu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "mætirðu",
+					"ft": "mætiði"
+				},
+				"þátíð": {
+					"et": "mættirðu",
+					"ft": "mættuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "mætirðu",
+					"ft": "mætiði"
+				},
+				"þátíð": {
+					"et": "mættirðu",
+					"ft": "mættuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "mætast",
+		"sagnbót": "mæst",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mætist", "mætist", "mætist"],
+					"ft": ["mætumst", "mætist", "mætast"]
+				},
+				"þátíð": {
+					"et": ["mættist", "mættist", "mættist"],
+					"ft": ["mættumst", "mættust", "mættust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mætist", "mætist", "mætist"],
+					"ft": ["mætumst", "mætist", "mætist"]
+				},
+				"þátíð": {
+					"et": ["mættist", "mættist", "mættist"],
+					"ft": ["mættumst", "mættust", "mættust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "mætistu"
+				},
+				"þátíð": {
+					"et": "mættistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "mætistu"
+				},
+				"þátíð": {
+					"et": "mættistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "mætandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["mættur", "mættan", "mættum", "mætts"],
+					"kvk": ["mætt", "mætta", "mættri", "mættrar"],
+					"hk": ["mætt", "mætt", "mættu", "mætts"]
+				},
+				"ft": {
+					"kk": ["mættir", "mætta", "mættum", "mættra"],
+					"kvk": ["mættar", "mættar", "mættum", "mættra"],
+					"hk": ["mætt", "mætt", "mættum", "mættra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["mætti", "mætta", "mætta", "mætta"],
+					"kvk": ["mætta", "mættu", "mættu", "mættu"],
+					"hk": ["mætta", "mætta", "mætta", "mætta"]
+				},
+				"ft": {
+					"kk": ["mættu", "mættu", "mættu", "mættu"],
+					"kvk": ["mættu", "mættu", "mættu", "mættu"],
+					"hk": ["mættu", "mættu", "mættu", "mættu"]
+				}
+			}
+		}
+	},
+	"hash": "f2f17981b6297900951f73ac894e2192cba4eb8ea9fef659aaeeb7577c5e6eef"
+}

--- a/lokaord/database/data/sagnord/nefna.json
+++ b/lokaord/database/data/sagnord/nefna.json
@@ -1,0 +1,131 @@
+{
+	"orð": "nefna",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "nefna",
+		"sagnbót": "nefnt",
+		"boðháttur": {
+			"stýfður": "nefn",
+			"et": "nefndu",
+			"ft": "nefnið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["nefni", "nefnir", "nefnir"],
+					"ft": ["nefnum", "nefnið", "nefna"]
+				},
+				"þátíð": {
+					"et": ["nefndi", "nefndir", "nefndi"],
+					"ft": ["nefndum", "nefnduð", "nefndu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["nefni", "nefnir", "nefni"],
+					"ft": ["nefnum", "nefnið", "nefni"]
+				},
+				"þátíð": {
+					"et": ["nefndi", "nefndir", "nefndi"],
+					"ft": ["nefndum", "nefnduð", "nefndu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "nefnirðu",
+					"ft": "nefniði"
+				},
+				"þátíð": {
+					"et": "nefndirðu",
+					"ft": "nefnduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "nefnirðu",
+					"ft": "nefniði"
+				},
+				"þátíð": {
+					"et": "nefndirðu",
+					"ft": "nefnduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "nefnast",
+		"sagnbót": "nefnst",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["nefnist", "nefnist", "nefnist"],
+					"ft": ["nefnumst", "nefnist", "nefnast"]
+				},
+				"þátíð": {
+					"et": ["nefndist", "nefndist", "nefndist"],
+					"ft": ["nefndumst", "nefndust", "nefndust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["nefnist", "nefnist", "nefnist"],
+					"ft": ["nefnumst", "nefnist", "nefnist"]
+				},
+				"þátíð": {
+					"et": ["nefndist", "nefndist", "nefndist"],
+					"ft": ["nefndumst", "nefndust", "nefndust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "nefnistu"
+				},
+				"þátíð": {
+					"et": "nefndistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "nefnistu"
+				},
+				"þátíð": {
+					"et": "nefndistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "nefnandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["nefndur", "nefndan", "nefndum", "nefnds"],
+					"kvk": ["nefnd", "nefnda", "nefndri", "nefndrar"],
+					"hk": ["nefnt", "nefnt", "nefndu", "nefnds"]
+				},
+				"ft": {
+					"kk": ["nefndir", "nefnda", "nefndum", "nefndra"],
+					"kvk": ["nefndar", "nefndar", "nefndum", "nefndra"],
+					"hk": ["nefnd", "nefnd", "nefndum", "nefndra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["nefndi", "nefnda", "nefnda", "nefnda"],
+					"kvk": ["nefnda", "nefndu", "nefndu", "nefndu"],
+					"hk": ["nefnda", "nefnda", "nefnda", "nefnda"]
+				},
+				"ft": {
+					"kk": ["nefndu", "nefndu", "nefndu", "nefndu"],
+					"kvk": ["nefndu", "nefndu", "nefndu", "nefndu"],
+					"hk": ["nefndu", "nefndu", "nefndu", "nefndu"]
+				}
+			}
+		}
+	},
+	"hash": "5cfb9dae81068785d8e9b920145662dd85079ab05bd98dde394e90f74ddae2a6"
+}

--- a/lokaord/database/data/sagnord/ná.json
+++ b/lokaord/database/data/sagnord/ná.json
@@ -1,0 +1,135 @@
+{
+	"orð": "ná",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "ná",
+		"sagnbót": "náð",
+		"boðháttur": {
+			"stýfður": "ná",
+			"et": "náðu",
+			"ft": "náið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["næ", "nærð", "nær"],
+					"ft": ["náum", "náið", "ná"]
+				},
+				"þátíð": {
+					"et": ["náði", "náðir", "náði"],
+					"ft": ["náðum", "náðuð", "náðu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["nái", "náir", "nái"],
+					"ft": ["náum", "náið", "nái"]
+				},
+				"þátíð": {
+					"et": ["næði", "næðir", "næði"],
+					"ft": ["næðum", "næðuð", "næðu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "nærðu",
+					"ft": "náiði"
+				},
+				"þátíð": {
+					"et": "náðirðu",
+					"ft": "náðuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "náirðu",
+					"ft": "náiði"
+				},
+				"þátíð": {
+					"et": "næðirðu",
+					"ft": "næðuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "nást",
+		"sagnbót": "náðst",
+		"boðháttur": {
+			"et": "náðstu",
+			"ft": "náist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["næst", "næst", "næst"],
+					"ft": ["náumst", "náist", "nást"]
+				},
+				"þátíð": {
+					"et": ["náðist", "náðist", "náðist"],
+					"ft": ["náðumst", "náðust", "náðust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["náist", "náist", "náist"],
+					"ft": ["náumst", "náist", "náist"]
+				},
+				"þátíð": {
+					"et": ["næðist", "næðist", "næðist"],
+					"ft": ["næðumst", "næðust", "næðust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "næstu"
+				},
+				"þátíð": {
+					"et": "náðistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "náistu"
+				},
+				"þátíð": {
+					"et": "næðistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "náandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["náður", "náðan", "náðum", "náðs"],
+					"kvk": ["náð", "náða", "náðri", "náðrar"],
+					"hk": ["náð", "náð", "náðu", "náðs"]
+				},
+				"ft": {
+					"kk": ["náðir", "náða", "náðum", "náðra"],
+					"kvk": ["náðar", "náðar", "náðum", "náðra"],
+					"hk": ["náð", "náð", "náðum", "náðra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["náði", "náða", "náða", "náða"],
+					"kvk": ["náða", "náðu", "náðu", "náðu"],
+					"hk": ["náða", "náða", "náða", "náða"]
+				},
+				"ft": {
+					"kk": ["náðu", "náðu", "náðu", "náðu"],
+					"kvk": ["náðu", "náðu", "náðu", "náðu"],
+					"hk": ["náðu", "náðu", "náðu", "náðu"]
+				}
+			}
+		}
+	},
+	"hash": "6ec4a9d56212050c346501de6eed375e4680b77fd4d185a2119c482c22d10e44"
+}

--- a/lokaord/database/data/sagnord/telja.json
+++ b/lokaord/database/data/sagnord/telja.json
@@ -1,0 +1,119 @@
+{
+	"orð": "telja",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "telja",
+		"sagnbót": "talið",
+		"boðháttur": {
+			"stýfður": "tel",
+			"et": "teldu",
+			"ft": "teljið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["tel", "telur", "telur"],
+					"ft": ["teljum", "teljið", "telja"]
+				},
+				"þátíð": {
+					"et": ["taldi", "taldir", "taldi"],
+					"ft": ["töldum", "tölduð", "töldu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["telji", "teljir", "telji"],
+					"ft": ["teljum", "teljið", "telji"]
+				},
+				"þátíð": {
+					"et": ["teldi", "teldir", "teldi"],
+					"ft": ["teldum", "telduð", "teldu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "telurðu",
+					"ft": "teljiði"
+				},
+				"þátíð": {
+					"et": "taldirðu",
+					"ft": "tölduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "teljirðu",
+					"ft": "teljiði"
+				},
+				"þátíð": {
+					"et": "teldirðu",
+					"ft": "telduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "teljast",
+		"sagnbót": "talist",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["telst", "telst", "telst"],
+					"ft": ["teljumst", "teljist", "teljast"]
+				},
+				"þátíð": {
+					"et": ["taldist", "taldist", "taldist"],
+					"ft": ["töldumst", "töldust", "töldust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["teljist", "teljist", "teljist"],
+					"ft": ["teljumst", "teljist", "teljist"]
+				},
+				"þátíð": {
+					"et": ["teldist", "teldist", "teldist"],
+					"ft": ["teldumst", "teldust", "teldust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "telstu"
+				},
+				"þátíð": {
+					"et": "taldistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "teljistu"
+				},
+				"þátíð": {
+					"et": "teldistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "teljandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["talinn", "talinn", "töldum", "talins"],
+					"kvk": ["talin", "talda", "taldri", "taldrar"],
+					"hk": ["talið", "talið", "töldu", "talins"]
+				},
+				"ft": {
+					"kk": ["taldir", "talda", "töldum", "taldra"],
+					"kvk": ["taldar", "taldar", "töldum", "taldra"],
+					"hk": ["talin", "talin", "töldum", "taldra"]
+				}
+			}
+		}
+	},
+	"hash": "9c81509630627744ae39aac0db44e006eaff389ddde9dfec6a24424098761e41"
+}

--- a/lokaord/database/data/sagnord/viðkoma.json
+++ b/lokaord/database/data/sagnord/viðkoma.json
@@ -1,0 +1,146 @@
+{
+	"orð": "viðkoma",
+	"flokkur": "sagnorð",
+	"samsett": [
+		{
+			"mynd": "við",
+			"samsetning": "stofn",
+			"orð": "við",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "efe2b19fd596f22370ecbfbfc531cfc8f6870b77cc4cdf30adcbc0e7c9d7e275"
+		},
+		{
+			"orð": "koma",
+			"flokkur": "sagnorð",
+			"hash": "ad011e3f5a9ce16138a8d3ad50c53a2524e679959d74bd54e42d2c39e26c3a51"
+		}
+	],
+	"germynd": {
+		"nafnháttur": "viðkoma",
+		"sagnbót": "viðkomið",
+		"boðháttur": {
+			"stýfður": "viðkom",
+			"et": "viðkomdu",
+			"ft": "viðkomið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["viðkem", "viðkemur", "viðkemur"],
+					"ft": ["viðkomum", "viðkomið", "viðkoma"]
+				},
+				"þátíð": {
+					"et": ["viðkom", "viðkomst", "viðkom"],
+					"ft": ["viðkomum", "viðkomuð", "viðkomu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["viðkomi", "viðkomir", "viðkomi"],
+					"ft": ["viðkomum", "viðkomið", "viðkomi"]
+				},
+				"þátíð": {
+					"et": ["viðkæmi", "viðkæmir", "viðkæmi"],
+					"ft": ["viðkæmum", "viðkæmuð", "viðkæmu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "viðkemurðu",
+					"ft": "viðkomiði"
+				},
+				"þátíð": {
+					"et": "viðkomstu",
+					"ft": "viðkomuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "viðkomirðu",
+					"ft": "viðkomiði"
+				},
+				"þátíð": {
+					"et": "viðkæmirðu",
+					"ft": "viðkæmuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "viðkomast",
+		"sagnbót": "viðkomist",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["viðkemst", "viðkemst", "viðkemst"],
+					"ft": ["viðkomumst", "viðkomist", "viðkomast"]
+				},
+				"þátíð": {
+					"et": ["viðkomst", "viðkomst", "viðkomst"],
+					"ft": ["viðkomumst", "viðkomust", "viðkomust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["viðkomist", "viðkomist", "viðkomist"],
+					"ft": ["viðkomumst", "viðkomist", "viðkomist"]
+				},
+				"þátíð": {
+					"et": ["viðkæmist", "viðkæmist", "viðkæmist"],
+					"ft": ["viðkæmumst", "viðkæmust", "viðkæmust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "viðkemstu"
+				},
+				"þátíð": {
+					"et": "viðkomstu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "viðkomistu"
+				},
+				"þátíð": {
+					"et": "viðkæmistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "viðkomandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["viðkominn", "viðkominn", "viðkomnum", "viðkomins"],
+					"kvk": ["viðkomin", "viðkomna", "viðkominni", "viðkominnar"],
+					"hk": ["viðkomið", "viðkomið", "viðkomnu", "viðkomins"]
+				},
+				"ft": {
+					"kk": ["viðkomnir", "viðkomna", "viðkomnum", "viðkominna"],
+					"kvk": ["viðkomnar", "viðkomnar", "viðkomnum", "viðkominna"],
+					"hk": ["viðkomin", "viðkomin", "viðkomnum", "viðkominna"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["viðkomni", "viðkomna", "viðkomna", "viðkomna"],
+					"kvk": ["viðkomna", "viðkomnu", "viðkomnu", "viðkomnu"],
+					"hk": ["viðkomna", "viðkomna", "viðkomna", "viðkomna"]
+				},
+				"ft": {
+					"kk": ["viðkomnu", "viðkomnu", "viðkomnu", "viðkomnu"],
+					"kvk": ["viðkomnu", "viðkomnu", "viðkomnu", "viðkomnu"],
+					"hk": ["viðkomnu", "viðkomnu", "viðkomnu", "viðkomnu"]
+				}
+			}
+		}
+	},
+	"hash": "07d9147be48e05cca7cfde4a20277a0be832efd3316210b1fbdc889679b70db4"
+}

--- a/lokaord/database/data/sagnord/útnefna.json
+++ b/lokaord/database/data/sagnord/útnefna.json
@@ -1,0 +1,146 @@
+{
+	"orð": "útnefna",
+	"flokkur": "sagnorð",
+	"samsett": [
+		{
+			"mynd": "út",
+			"samsetning": "stofn",
+			"orð": "út",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "bcc080fc5650301997f155af20fb6b00dc8e66f2777dcc3181d12c79d4761fbd"
+		},
+		{
+			"orð": "nefna",
+			"flokkur": "sagnorð",
+			"hash": "5cfb9dae81068785d8e9b920145662dd85079ab05bd98dde394e90f74ddae2a6"
+		}
+	],
+	"germynd": {
+		"nafnháttur": "útnefna",
+		"sagnbót": "útnefnt",
+		"boðháttur": {
+			"stýfður": "útnefn",
+			"et": "útnefndu",
+			"ft": "útnefnið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["útnefni", "útnefnir", "útnefnir"],
+					"ft": ["útnefnum", "útnefnið", "útnefna"]
+				},
+				"þátíð": {
+					"et": ["útnefndi", "útnefndir", "útnefndi"],
+					"ft": ["útnefndum", "útnefnduð", "útnefndu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["útnefni", "útnefnir", "útnefni"],
+					"ft": ["útnefnum", "útnefnið", "útnefni"]
+				},
+				"þátíð": {
+					"et": ["útnefndi", "útnefndir", "útnefndi"],
+					"ft": ["útnefndum", "útnefnduð", "útnefndu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "útnefnirðu",
+					"ft": "útnefniði"
+				},
+				"þátíð": {
+					"et": "útnefndirðu",
+					"ft": "útnefnduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "útnefnirðu",
+					"ft": "útnefniði"
+				},
+				"þátíð": {
+					"et": "útnefndirðu",
+					"ft": "útnefnduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "útnefnast",
+		"sagnbót": "útnefnst",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["útnefnist", "útnefnist", "útnefnist"],
+					"ft": ["útnefnumst", "útnefnist", "útnefnast"]
+				},
+				"þátíð": {
+					"et": ["útnefndist", "útnefndist", "útnefndist"],
+					"ft": ["útnefndumst", "útnefndust", "útnefndust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["útnefnist", "útnefnist", "útnefnist"],
+					"ft": ["útnefnumst", "útnefnist", "útnefnist"]
+				},
+				"þátíð": {
+					"et": ["útnefndist", "útnefndist", "útnefndist"],
+					"ft": ["útnefndumst", "útnefndust", "útnefndust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "útnefnistu"
+				},
+				"þátíð": {
+					"et": "útnefndistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "útnefnistu"
+				},
+				"þátíð": {
+					"et": "útnefndistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "útnefnandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["útnefndur", "útnefndan", "útnefndum", "útnefnds"],
+					"kvk": ["útnefnd", "útnefnda", "útnefndri", "útnefndrar"],
+					"hk": ["útnefnt", "útnefnt", "útnefndu", "útnefnds"]
+				},
+				"ft": {
+					"kk": ["útnefndir", "útnefnda", "útnefndum", "útnefndra"],
+					"kvk": ["útnefndar", "útnefndar", "útnefndum", "útnefndra"],
+					"hk": ["útnefnd", "útnefnd", "útnefndum", "útnefndra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["útnefndi", "útnefnda", "útnefnda", "útnefnda"],
+					"kvk": ["útnefnda", "útnefndu", "útnefndu", "útnefndu"],
+					"hk": ["útnefnda", "útnefnda", "útnefnda", "útnefnda"]
+				},
+				"ft": {
+					"kk": ["útnefndu", "útnefndu", "útnefndu", "útnefndu"],
+					"kvk": ["útnefndu", "útnefndu", "útnefndu", "útnefndu"],
+					"hk": ["útnefndu", "útnefndu", "útnefndu", "útnefndu"]
+				}
+			}
+		}
+	},
+	"hash": "51f473e9b9231beb3a27fac6ec54676ade031bcd7e1bf07cb6f750a382528fb9"
+}

--- a/lokaord/database/data/sernofn/mannanofn/islensk-karlmannsnofn/eigin/Davíð.json
+++ b/lokaord/database/data/sernofn/mannanofn/islensk-karlmannsnofn/eigin/Davíð.json
@@ -1,0 +1,10 @@
+{
+	"orð": "Davíð",
+	"flokkur": "sérnafn",
+	"undirflokkur": "eiginnafn",
+	"kyn": "kk",
+	"et": {
+		"ág": ["Davíð", "Davíð", "Davíð", "Davíðs"]
+	},
+	"hash": "ea95a049b17f970ed626e43c4b7394be00810055e4e5e135b2ade317e9c7082f"
+}

--- a/lokaord/database/data/sernofn/mannanofn/islensk-karlmannsnofn/eigin/Magnús.json
+++ b/lokaord/database/data/sernofn/mannanofn/islensk-karlmannsnofn/eigin/Magnús.json
@@ -1,0 +1,10 @@
+{
+	"orð": "Magnús",
+	"flokkur": "sérnafn",
+	"undirflokkur": "eiginnafn",
+	"kyn": "kk",
+	"et": {
+		"ág": ["Magnús", "Magnús", "Magnúsi", "Magnúsar"]
+	},
+	"hash": "7ccd7e3b9cef5b7ba2f9ea7b9d9e21b239d9104380693ad2884348a090448710"
+}

--- a/lokaord/database/data/sernofn/mannanofn/islensk-millinofn/Norðdahl.json
+++ b/lokaord/database/data/sernofn/mannanofn/islensk-millinofn/Norðdahl.json
@@ -1,0 +1,6 @@
+{
+	"orð": "Norðdahl",
+	"flokkur": "sérnafn",
+	"undirflokkur": "millinafn",
+	"hash": "3e8d3b0c294e6d1ec29401a8c8c82c2d253bfb539f6d1bfb08bcfde580434aee"
+}

--- a/lokaord/database/data/sernofn/ornefni/Borgarnes-hk.json
+++ b/lokaord/database/data/sernofn/ornefni/Borgarnes-hk.json
@@ -1,0 +1,27 @@
+{
+	"orð": "Borgarnes",
+	"flokkur": "sérnafn",
+	"undirflokkur": "örnefni",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "Borgar",
+			"samsetning": "eignarfalls",
+			"orð": "borg",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"hash": "f19f3ce8af0f39c8188d8efd811c4c8781210c17618cc98ddefb52d0b400f10a"
+		},
+		{
+			"orð": "nes",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"beygingar": ["et-ág"],
+			"hash": "53e932759a893822343d75a10538df189dcd58b764d9051b759dd5d0ef01677b"
+		}
+	],
+	"et": {
+		"ág": ["Borgarnes", "Borgarnes", "Borgarnesi", "Borgarness"]
+	},
+	"hash": "701ddbf4211365bf29fb729a3d886e2031b6f0b47b698c15fe48155417a2d0cd"
+}

--- a/lokaord/database/data/sernofn/ornefni/Norðvesturkjördæmi-hk.json
+++ b/lokaord/database/data/sernofn/ornefni/Norðvesturkjördæmi-hk.json
@@ -1,0 +1,44 @@
+{
+	"orð": "Norðvesturkjördæmi",
+	"flokkur": "sérnafn",
+	"undirflokkur": "örnefni",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "Norð",
+			"samsetning": "stofn",
+			"orð": "norður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b2e5fb6c4e5f889465a961360d917e9bd70b236aa95440e20ba7555cb7215c90"
+		},
+		{
+			"mynd": "vestur",
+			"samsetning": "stofn",
+			"orð": "vestur",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "f1b905deecda3ed00ccdbde2e95a2373952b0672e82df60567df27011840cf8b"
+		},
+		{
+			"mynd": "kjör",
+			"samsetning": "stofn",
+			"orð": "kjör",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"merking": "kosning",
+			"hash": "851a58c80b59600df3c79bf82b663dcc868620250960ca31178ab284deb3c83c"
+		},
+		{
+			"orð": "dæmi",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"beygingar": ["et-ág"],
+			"hash": "c41d75ce758174047306ad83572f3c542862c78e8e70f41a6f78df5fef79d38a"
+		}
+	],
+	"et": {
+		"ág": ["Norðvesturkjördæmi", "Norðvesturkjördæmi", "Norðvesturkjördæmi", "Norðvesturkjördæmis"]
+	},
+	"hash": "f61e91de877ecee82f983fcbbd08ed28e519c34e1381df37b079584f08609f17"
+}

--- a/lokaord/database/data/sernofn/ornefni/Pírati-kk.json
+++ b/lokaord/database/data/sernofn/ornefni/Pírati-kk.json
@@ -1,0 +1,24 @@
+{
+	"orð": "Pírati",
+	"flokkur": "sérnafn",
+	"undirflokkur": "örnefni",
+	"kyn": "kk",
+	"samsett": [
+		{
+			"orð": "pírati",
+			"flokkur": "nafnorð",
+			"kyn": "kk",
+			"hástafa": true,
+			"hash": "0bd792a9c80202d70849ab4f4b1cec20da7696908070c0c69b0ffaedcdfc0430"
+		}
+	],
+	"et": {
+		"ág": ["Pírati", "Pírata", "Pírata", "Pírata"],
+		"mg": ["Píratinn", "Píratann", "Píratanum", "Píratans"]
+	},
+	"ft": {
+		"ág": ["Píratar", "Pírata", "Pírötum", "Pírata"],
+		"mg": ["Píratarnir", "Píratana", "Pírötunum", "Píratanna"]
+	},
+	"hash": "1d455b7d8b181751f713fb62abb10f07c53e0f5a1c2c9f22601fd8105706295f"
+}

--- a/lokaord/database/data/smaord/atviksord/austur.json
+++ b/lokaord/database/data/smaord/atviksord/austur.json
@@ -1,0 +1,8 @@
+{
+	"orð": "austur",
+	"flokkur": "smáorð",
+	"undirflokkur": "atviksorð",
+	"miðstig": "austar",
+	"efstastig": "austast",
+	"hash": "d3f4db91bcaa9a0dd92e22141fc265273bd4989f3b45da8a3a8a4d7a7ef221d9"
+}

--- a/lokaord/database/data/smaord/atviksord/mis.json
+++ b/lokaord/database/data/smaord/atviksord/mis.json
@@ -1,0 +1,6 @@
+{
+	"orð": "mis",
+	"flokkur": "smáorð",
+	"undirflokkur": "atviksorð",
+	"hash": "9f316137de59e14bd826323e57541b07ed4118eb2fb9f8cb1909385261b34f95"
+}

--- a/lokaord/database/data/smaord/atviksord/norður.json
+++ b/lokaord/database/data/smaord/atviksord/norður.json
@@ -1,0 +1,8 @@
+{
+	"orð": "norður",
+	"flokkur": "smáorð",
+	"undirflokkur": "atviksorð",
+	"miðstig": "norðar",
+	"efstastig": "nyrst",
+	"hash": "a2c593983472b156e0c8da0b97df95f98955ca2581e321c29abd49917ff3d33b"
+}

--- a/lokaord/database/data/smaord/atviksord/suður.json
+++ b/lokaord/database/data/smaord/atviksord/suður.json
@@ -1,0 +1,8 @@
+{
+	"orð": "suður",
+	"flokkur": "smáorð",
+	"undirflokkur": "atviksorð",
+	"miðstig": "sunnar",
+	"efstastig": "syðst",
+	"hash": "bbd23dae04a087c8dc6f5bc8d477086eeb0369734cca844a55236f450c37c54a"
+}

--- a/lokaord/database/data/smaord/atviksord/vestur.json
+++ b/lokaord/database/data/smaord/atviksord/vestur.json
@@ -1,0 +1,8 @@
+{
+	"orð": "vestur",
+	"flokkur": "smáorð",
+	"undirflokkur": "atviksorð",
+	"miðstig": "vestar",
+	"efstastig": "vestast",
+	"hash": "49240336f8eff1cf5a1070c999072e032a3907de2e1c25ac9af8c75c16ff15d2"
+}

--- a/lokaord/database/data/smaord/forsetning/norðaustan.json
+++ b/lokaord/database/data/smaord/forsetning/norðaustan.json
@@ -1,0 +1,25 @@
+{
+	"orð": "norðaustan",
+	"flokkur": "smáorð",
+	"undirflokkur": "forsetning",
+	"stýrir": ["eignarfall"],
+	"samsett": [
+		{
+			"mynd": "norð",
+			"samsetning": "stofn",
+			"orð": "norður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b2e5fb6c4e5f889465a961360d917e9bd70b236aa95440e20ba7555cb7215c90"
+		},
+		{
+			"mynd": "austan",
+			"samsetning": "stofn",
+			"orð": "austan",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "5a28513f4d0ee1aa131c2cb9297ce23c19ce80fd7179138ae3797968e72bb0d7"
+		}
+	],
+	"hash": "54426bf4bf9501d0edd30e88dbf7aa149ec4ba4ee38fb2219b657ab6a4a01c39"
+}

--- a/lokaord/database/data/smaord/forsetning/norðvestan.json
+++ b/lokaord/database/data/smaord/forsetning/norðvestan.json
@@ -1,0 +1,25 @@
+{
+	"orð": "norðvestan",
+	"flokkur": "smáorð",
+	"undirflokkur": "forsetning",
+	"stýrir": ["eignarfall"],
+	"samsett": [
+		{
+			"mynd": "norð",
+			"samsetning": "stofn",
+			"orð": "norður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b2e5fb6c4e5f889465a961360d917e9bd70b236aa95440e20ba7555cb7215c90"
+		},
+		{
+			"mynd": "vestan",
+			"samsetning": "stofn",
+			"orð": "vestan",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "448fe68fa0c038f8830ddce67fb7e435d03e6ffac3586142effc300a5e58c418"
+		}
+	],
+	"hash": "4ef780bf59dc06ff077ca84c1b2a927652c0911641bd58b633de60d5b59505ad"
+}

--- a/lokaord/database/data/smaord/forsetning/suðaustan.json
+++ b/lokaord/database/data/smaord/forsetning/suðaustan.json
@@ -1,0 +1,25 @@
+{
+	"orð": "suðaustan",
+	"flokkur": "smáorð",
+	"undirflokkur": "forsetning",
+	"stýrir": ["eignarfall"],
+	"samsett": [
+		{
+			"mynd": "suð",
+			"samsetning": "stofn",
+			"orð": "suður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "8d80e5d622dbab3685e23cf2d97c6aadb6fb31860418092a4048dd98d1a4b1a2"
+		},
+		{
+			"mynd": "austan",
+			"samsetning": "stofn",
+			"orð": "austan",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "5a28513f4d0ee1aa131c2cb9297ce23c19ce80fd7179138ae3797968e72bb0d7"
+		}
+	],
+	"hash": "7f5287a9bfd07085f90a1a99d05c9f3e06b380c758aebea27236977d6586c02e"
+}

--- a/lokaord/database/data/smaord/forsetning/suðvestan.json
+++ b/lokaord/database/data/smaord/forsetning/suðvestan.json
@@ -1,0 +1,25 @@
+{
+	"orð": "suðvestan",
+	"flokkur": "smáorð",
+	"undirflokkur": "forsetning",
+	"stýrir": ["eignarfall"],
+	"samsett": [
+		{
+			"mynd": "suð",
+			"samsetning": "stofn",
+			"orð": "suður",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "8d80e5d622dbab3685e23cf2d97c6aadb6fb31860418092a4048dd98d1a4b1a2"
+		},
+		{
+			"mynd": "vestan",
+			"samsetning": "stofn",
+			"orð": "vestan",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "448fe68fa0c038f8830ddce67fb7e435d03e6ffac3586142effc300a5e58c418"
+		}
+	],
+	"hash": "3c9da4137f2104323069ddbf32bcdbc6ff1f2d2357e19f0f5d5e8b19acf768bf"
+}

--- a/lokaord/exporter.py
+++ b/lokaord/exporter.py
@@ -86,7 +86,7 @@ def write_datafiles_from_db():
             'root': datafiles_dir_abs,
             'dir': os.path.join('smaord', 'forsetning'),
             'f_ord_to_dict': get_forsetning_from_db_to_ordered_dict,
-            'has_samsett': False
+            'has_samsett': True
         },
         {
             'name': 'atviksorð',
@@ -1104,6 +1104,9 @@ def get_samsett_ord_from_db_to_ordered_dict(isl_ord, ord_id_hash_map=None):
     if flokkur in toluord_undirflokkar:
         data['flokkur'] = 'töluorð'
         data['undirflokkur'] = flokkur
+    elif flokkur in smaord_undirflokkar:
+        data['flokkur'] = 'smáorð'
+        data['undirflokkur'] = flokkur
     else:
         data['flokkur'] = flokkur
     if isl_ord.Ordflokkur is isl.Ordflokkar.Nafnord:
@@ -1136,6 +1139,8 @@ def get_samsett_ord_from_db_to_ordered_dict(isl_ord, ord_id_hash_map=None):
             data['persóna'] = persona_to_str(isl_fornafn.Persona)
         if isl_fornafn.Kyn is not None:
             data['kyn'] = kyn_to_str(isl_fornafn.Kyn)
+    elif isl_ord.Ordflokkur is isl.Ordflokkar.Forsetning:
+        data['stýrir'] = get_forsetning_from_db_to_ordered_dict(isl_ord)['stýrir']
     elif isl_ord.Ordflokkur is isl.Ordflokkar.Sernafn:
         isl_sernafn_query = db.Session.query(isl.Sernafn).filter_by(fk_Ord_id=isl_ord.Ord_id)
         assert(len(isl_sernafn_query.all()) < 2)
@@ -1755,7 +1760,9 @@ def add_framhluti_to_ord_data(
     helper function for constructing beygingarmyndir data for samsett orð
     '''
     dictorinos = (dict, collections.OrderedDict)
-    ignore_keys = set(['orð', 'flokkur', 'undirflokkur', 'kyn', 'gildi', 'hash', 'ósjálfstætt'])
+    ignore_keys = set([
+        'orð', 'flokkur', 'undirflokkur', 'kyn', 'gildi', 'hash', 'ósjálfstætt', 'stýrir'
+    ])
     dont_change_keys = set(['frumlag'])
     new_ord_data = None
     if type(ord_data) is dict:

--- a/lokaord/importer.py
+++ b/lokaord/importer.py
@@ -128,7 +128,7 @@ def build_db_from_datafiles():
             'dir': os.path.join('smaord', 'forsetning'),
             'f_lookup': lookup_forsetning,
             'f_add': add_forsetning,
-            'has_samsett': False
+            'has_samsett': True
         },
         {
             'name': 'smáorð, atviksorð',
@@ -646,7 +646,14 @@ def add_sagnord(sagnord_data, merking=None):
     add sagnorð from datafile to database
     '''
     assert('flokkur' in sagnord_data and sagnord_data['flokkur'] == 'sagnorð')
-    isl_ord = isl.Ord(Ord=sagnord_data['orð'], Ordflokkur=isl.Ordflokkar.Sagnord, Merking=merking)
+    isl_ord = isl.Ord(
+        Ord=sagnord_data['orð'],
+        Ordflokkur=isl.Ordflokkar.Sagnord,
+        OsjalfstaedurOrdhluti=(
+            'ósjálfstætt' in sagnord_data and sagnord_data['ósjálfstætt'] is True
+        ),
+        Merking=merking
+    )
     db.Session.add(isl_ord)
     db.Session.commit()
     isl_sagnord = isl.Sagnord(fk_Ord_id=isl_ord.Ord_id)
@@ -1736,6 +1743,10 @@ def add_forsetning(forsetning_data, merking=None):
         else:
             raise Exception('Unknown aukafall.')
     db.Session.commit()
+    if 'samsett' in forsetning_data:
+        add_samsett_ord(isl_ord.Ord_id, forsetning_data)
+        isl_ord.Samsett = True
+        db.Session.commit()
     return isl_ord
 
 

--- a/lokaord/seer.py
+++ b/lokaord/seer.py
@@ -53,16 +53,21 @@ def scan_sentence(sentence):
         scanned_word = {
             'orð': word,
             'orð-hreinsað': None,
+            'leiðir': None,
             'fylgir': None,
             'staða': None,
             'möguleikar': []
         }
         if word not in sight['orð']:
+            onhanging_chars = set(['.', ',', '(', ')', '[', ']'])
             msg = ''
             e_word = word.strip()
-            if e_word[-1] in ('.', ','):
+            if e_word[-1] in onhanging_chars:
                 scanned_word['fylgir'] = e_word[-1]
                 e_word = e_word[:-1]
+            if e_word[0] in onhanging_chars:
+                scanned_word['leiðir'] = e_word[0]
+                e_word = e_word[1:]
             if e_word not in sight['orð'] and 'll' in e_word:
                 e_word = e_word.replace('ll', 'łl')
             if e_word not in sight['orð']:
@@ -104,7 +109,8 @@ def scan_sentence(sentence):
                 scanned_word['orð-hreinsað']
             ))
             highlighted_sentence_list.append(
-                '%s%s' % (
+                '%s%s%s' % (
+                    '' if scanned_word['leiðir'] is None else scanned_word['leiðir'],
                     '\033[43m\033[30m%s\033[0m' % (scanned_word['orð-hreinsað'], ),
                     '' if scanned_word['fylgir'] is None else scanned_word['fylgir']
                 )
@@ -276,6 +282,46 @@ def build_sight(filename='sight', use_pointless=None):
             'name': 'smáorð, upphrópun',
             'root': datafiles_dir_abs,
             'dir': os.path.join('smaord', 'upphropun'),
+        },
+        {
+            'name': 'sérnöfn, eiginnafn (kk)',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-karlmannsnofn', 'eigin'),
+        },
+        {
+            'name': 'sérnöfn, gælunafn (kk)',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-karlmannsnofn', 'gaelu'),
+        },
+        {
+            'name': 'sérnöfn, kenninafn (kk)',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-karlmannsnofn', 'kenni'),
+        },
+        {
+            'name': 'sérnöfn, eiginnafn (kvk)',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-kvenmannsnofn', 'eigin'),
+        },
+        {
+            'name': 'sérnöfn, gælunafn (kvk)',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-kvenmannsnofn', 'gaelu'),
+        },
+        {
+            'name': 'sérnöfn, kenninafn (kvk)',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-kvenmannsnofn', 'kenni'),
+        },
+        {
+            'name': 'sérnöfn, miłlinafn',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'mannanofn', 'islensk-millinofn'),
+        },
+        {
+            'name': 'sérnöfn, örnefni',
+            'root': datafiles_dir_abs,
+            'dir': os.path.join('sernofn', 'ornefni'),
         }
     ]
     for task in knowledge_tasks:
@@ -292,6 +338,7 @@ def build_sight(filename='sight', use_pointless=None):
                 ord_mynd += '.%s' % (ord_data['kyn'], )
             if (
                 ord_mynd.startswith('smáorð') or
+                ord_mynd == 'sérnafn.millinafn' or
                 ('óbeygjanlegt' in ord_data and ord_data['óbeygjanlegt'] is True)
             ):
                 if ord_data['orð'] not in sight['orð']:


### PR DESCRIPTION
bætti við orðum sem vantaði fyrir eftirfarandi málsgrein

`python main.py --scan-sentence "Málið fer á flug þegar frambjóðandi fyrsta sætis Pírata í norðvestur, Magnús Davíð Norðdahl, mætir á Hótel Borgarnes þar sem atkvæðin í norðvestur höfðu verið talin og endurtalning var nú í fullum gangi. Þegar kjörbréfanefndir framkvæma talningu atkvæða hvílir á þeim lagaleg skylda að kalla til fulltrúa allra flokka í framboði til að sinna eftirlitshlutverki. Misfarist að ná í einhvern fulltrúa eða hafi fulltrúi ekki tök á að mæta ber kjörbréfanefnd lagaleg skylda að útnefna aðila til að sinna eftirlitshlutverki fyrir viðkomandi. Þegar kom að fulltrúa fyrir flokk Pírata hafði yfirkjörstjórn norðvestur ekki náð í aðila sem yfirkjörstjórn taldi vera fulltrúa Pírata fyrir Norðvesturkjördæmi."`

málsgreinin er héðan: https://kjarninn.is/skodun/upprifjun-endurtalningarinnar-i-nordvestur/

lagfærði að auki nokkra hluti:

* hafa sérnöfn með í sjón sjáanda
* meðhöndla samsett sagnorð rétt
* ofl