### PR TITLE
Add words loknar 2022-12-18

### DIFF
--- a/lokaord/database/data/lysingarord/lögmæltur.json
+++ b/lokaord/database/data/lysingarord/lögmæltur.json
@@ -1,0 +1,86 @@
+{
+	"orð": "lögmæltur",
+	"flokkur": "lýsingarorð",
+	"samsett": [
+		{
+			"mynd": "lög",
+			"samsetning": "stofn",
+			"orð": "lög",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "b085113d03044626996891a0af7cf4cff57cb5f238fd965d3da923b34891cdd8"
+		},
+		{
+			"orð": "mæltur",
+			"flokkur": "lýsingarorð",
+			"hash": "9dde2eb40e861a426255c3d154ea2d85f216da9c5ce2ef7ea6d5370c755f3e47"
+		}
+	],
+	"frumstig": {
+		"sb": {
+			"et": {
+				"kk": ["lögmæltur", "lögmæltan", "lögmæltum", "lögmælts"],
+				"kvk": ["lögmælt", "lögmælta", "lögmæltri", "lögmæltrar"],
+				"hk": ["lögmæltt", "lögmæltt", "lögmæltu", "lögmælts"]
+			},
+			"ft": {
+				"kk": ["lögmæltir", "lögmælta", "lögmæltum", "lögmæltra"],
+				"kvk": ["lögmæltar", "lögmæltar", "lögmæltum", "lögmæltra"],
+				"hk": ["lögmælt", "lögmælt", "lögmæltum", "lögmæltra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["lögmælti", "lögmælta", "lögmælta", "lögmælta"],
+				"kvk": ["lögmælta", "lögmæltu", "lögmæltu", "lögmæltu"],
+				"hk": ["lögmælta", "lögmælta", "lögmælta", "lögmælta"]
+			},
+			"ft": {
+				"kk": ["lögmæltu", "lögmæltu", "lögmæltu", "lögmæltu"],
+				"kvk": ["lögmæltu", "lögmæltu", "lögmæltu", "lögmæltu"],
+				"hk": ["lögmæltu", "lögmæltu", "lögmæltu", "lögmæltu"]
+			}
+		}
+	},
+	"miðstig": {
+		"vb": {
+			"et": {
+				"kk": ["lögmæltari", "lögmæltari", "lögmæltari", "lögmæltari"],
+				"kvk": ["lögmæltari", "lögmæltari", "lögmæltari", "lögmæltari"],
+				"hk": ["lögmæltara", "lögmæltara", "lögmæltara", "lögmæltara"]
+			},
+			"ft": {
+				"kk": ["lögmæltari", "lögmæltari", "lögmæltari", "lögmæltari"],
+				"kvk": ["lögmæltari", "lögmæltari", "lögmæltari", "lögmæltari"],
+				"hk": ["lögmæltari", "lögmæltari", "lögmæltari", "lögmæltari"]
+			}
+		}
+	},
+	"efstastig": {
+		"sb": {
+			"et": {
+				"kk": ["lögmæltastur", "lögmæltastan", "lögmæltustum", "lögmæltasts"],
+				"kvk": ["lögmæltust", "lögmæltasta", "lögmæltastri", "lögmæltastrar"],
+				"hk": ["lögmæltast", "lögmæltast", "lögmæltustu", "lögmæltasts"]
+			},
+			"ft": {
+				"kk": ["lögmæltastir", "lögmæltasta", "lögmæltustum", "lögmæltastra"],
+				"kvk": ["lögmæltastar", "lögmæltastar", "lögmæltustum", "lögmæltastra"],
+				"hk": ["lögmæltust", "lögmæltust", "lögmæltustum", "lögmæltastra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["lögmæltasti", "lögmæltasta", "lögmæltasta", "lögmæltasta"],
+				"kvk": ["lögmæltasta", "lögmæltustu", "lögmæltustu", "lögmæltustu"],
+				"hk": ["lögmæltasta", "lögmæltasta", "lögmæltasta", "lögmæltasta"]
+			},
+			"ft": {
+				"kk": ["lögmæltustu", "lögmæltustu", "lögmæltustu", "lögmæltustu"],
+				"kvk": ["lögmæltustu", "lögmæltustu", "lögmæltustu", "lögmæltustu"],
+				"hk": ["lögmæltustu", "lögmæltustu", "lögmæltustu", "lögmæltustu"]
+			}
+		}
+	},
+	"hash": "26da19d57ccb8e413c0fa7657111737a2a3e0289774b51992c68b2aec0b7cb37"
+}

--- a/lokaord/database/data/lysingarord/mældur.json
+++ b/lokaord/database/data/lysingarord/mældur.json
@@ -1,0 +1,71 @@
+{
+	"orð": "mældur",
+	"flokkur": "lýsingarorð",
+	"frumstig": {
+		"sb": {
+			"et": {
+				"kk": ["mældur", "mældan", "mældum", "mælds"],
+				"kvk": ["mæld", "mælda", "mældri", "mældrar"],
+				"hk": ["mældt", "mældt", "mældu", "mælds"]
+			},
+			"ft": {
+				"kk": ["mældir", "mælda", "mældum", "mældra"],
+				"kvk": ["mældar", "mældar", "mældum", "mældra"],
+				"hk": ["mæld", "mæld", "mældum", "mældra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["mældi", "mælda", "mælda", "mælda"],
+				"kvk": ["mælda", "mældu", "mældu", "mældu"],
+				"hk": ["mælda", "mælda", "mælda", "mælda"]
+			},
+			"ft": {
+				"kk": ["mældu", "mældu", "mældu", "mældu"],
+				"kvk": ["mældu", "mældu", "mældu", "mældu"],
+				"hk": ["mældu", "mældu", "mældu", "mældu"]
+			}
+		}
+	},
+	"miðstig": {
+		"vb": {
+			"et": {
+				"kk": ["mældari", "mældari", "mældari", "mældari"],
+				"kvk": ["mældari", "mældari", "mældari", "mældari"],
+				"hk": ["mældara", "mældara", "mældara", "mældara"]
+			},
+			"ft": {
+				"kk": ["mældari", "mældari", "mældari", "mældari"],
+				"kvk": ["mældari", "mældari", "mældari", "mældari"],
+				"hk": ["mældari", "mældari", "mældari", "mældari"]
+			}
+		}
+	},
+	"efstastig": {
+		"sb": {
+			"et": {
+				"kk": ["mældastur", "mældastan", "mældustum", "mældasts"],
+				"kvk": ["mældust", "mældasta", "mældastri", "mældastrar"],
+				"hk": ["mældast", "mældast", "mældustu", "mældasts"]
+			},
+			"ft": {
+				"kk": ["mældastir", "mældasta", "mældustum", "mældastra"],
+				"kvk": ["mældastar", "mældastar", "mældustum", "mældastra"],
+				"hk": ["mældust", "mældust", "mældustum", "mældastra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["mældasti", "mældasta", "mældasta", "mældasta"],
+				"kvk": ["mældasta", "mældustu", "mældustu", "mældustu"],
+				"hk": ["mældasta", "mældasta", "mældasta", "mældasta"]
+			},
+			"ft": {
+				"kk": ["mældustu", "mældustu", "mældustu", "mældustu"],
+				"kvk": ["mældustu", "mældustu", "mældustu", "mældustu"],
+				"hk": ["mældustu", "mældustu", "mældustu", "mældustu"]
+			}
+		}
+	},
+	"hash": "0c8357c80526e201ed4b6a32fde75712d671bc8210025e9dd1ff5dc7b1fcd12b"
+}

--- a/lokaord/database/data/lysingarord/mæltur.json
+++ b/lokaord/database/data/lysingarord/mæltur.json
@@ -1,0 +1,71 @@
+{
+	"orð": "mæltur",
+	"flokkur": "lýsingarorð",
+	"frumstig": {
+		"sb": {
+			"et": {
+				"kk": ["mæltur", "mæltan", "mæltum", "mælts"],
+				"kvk": ["mælt", "mælta", "mæltri", "mæltrar"],
+				"hk": ["mæltt", "mæltt", "mæltu", "mælts"]
+			},
+			"ft": {
+				"kk": ["mæltir", "mælta", "mæltum", "mæltra"],
+				"kvk": ["mæltar", "mæltar", "mæltum", "mæltra"],
+				"hk": ["mælt", "mælt", "mæltum", "mæltra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["mælti", "mælta", "mælta", "mælta"],
+				"kvk": ["mælta", "mæltu", "mæltu", "mæltu"],
+				"hk": ["mælta", "mælta", "mælta", "mælta"]
+			},
+			"ft": {
+				"kk": ["mæltu", "mæltu", "mæltu", "mæltu"],
+				"kvk": ["mæltu", "mæltu", "mæltu", "mæltu"],
+				"hk": ["mæltu", "mæltu", "mæltu", "mæltu"]
+			}
+		}
+	},
+	"miðstig": {
+		"vb": {
+			"et": {
+				"kk": ["mæltari", "mæltari", "mæltari", "mæltari"],
+				"kvk": ["mæltari", "mæltari", "mæltari", "mæltari"],
+				"hk": ["mæltara", "mæltara", "mæltara", "mæltara"]
+			},
+			"ft": {
+				"kk": ["mæltari", "mæltari", "mæltari", "mæltari"],
+				"kvk": ["mæltari", "mæltari", "mæltari", "mæltari"],
+				"hk": ["mæltari", "mæltari", "mæltari", "mæltari"]
+			}
+		}
+	},
+	"efstastig": {
+		"sb": {
+			"et": {
+				"kk": ["mæltastur", "mæltastan", "mæltustum", "mæltasts"],
+				"kvk": ["mæltust", "mæltasta", "mæltastri", "mæltastrar"],
+				"hk": ["mæltast", "mæltast", "mæltustu", "mæltasts"]
+			},
+			"ft": {
+				"kk": ["mæltastir", "mæltasta", "mæltustum", "mæltastra"],
+				"kvk": ["mæltastar", "mæltastar", "mæltustum", "mæltastra"],
+				"hk": ["mæltust", "mæltust", "mæltustum", "mæltastra"]
+			}
+		},
+		"vb": {
+			"et": {
+				"kk": ["mæltasti", "mæltasta", "mæltasta", "mæltasta"],
+				"kvk": ["mæltasta", "mæltustu", "mæltustu", "mæltustu"],
+				"hk": ["mæltasta", "mæltasta", "mæltasta", "mæltasta"]
+			},
+			"ft": {
+				"kk": ["mæltustu", "mæltustu", "mæltustu", "mæltustu"],
+				"kvk": ["mæltustu", "mæltustu", "mæltustu", "mæltustu"],
+				"hk": ["mæltustu", "mæltustu", "mæltustu", "mæltustu"]
+			}
+		}
+	},
+	"hash": "9dde2eb40e861a426255c3d154ea2d85f216da9c5ce2ef7ea6d5370c755f3e47"
+}

--- a/lokaord/database/data/nafnord/eftirlaun-hk.json
+++ b/lokaord/database/data/nafnord/eftirlaun-hk.json
@@ -1,0 +1,26 @@
+{
+	"orð": "eftirlaun",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "eftir",
+			"samsetning": "stofn",
+			"orð": "eftir",
+			"flokkur": "smáorð",
+			"undirflokkur": "forsetning",
+			"hash": "1efed85781de54b8146681802a59ee440e382f821da030774d1a24d01e6b2e4a"
+		},
+		{
+			"orð": "laun",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "954e7d972c12f8c859b61ea283a16f5d525bebc14bfacbcb50542a766aa81e91"
+		}
+	],
+	"ft": {
+		"ág": ["eftirlaun", "eftirlaun", "eftirlaunum", "eftirlauna"],
+		"mg": ["eftirlaunin", "eftirlaunin", "eftirlaununum", "eftirlaunanna"]
+	},
+	"hash": "e5354520a381a1857bbc91d02f6e75134281550cbfb903b49bec5542d28909ca"
+}

--- a/lokaord/database/data/nafnord/embættaskipti-hk.json
+++ b/lokaord/database/data/nafnord/embættaskipti-hk.json
@@ -1,0 +1,27 @@
+{
+	"orð": "embættaskipti",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "embætta",
+			"samsetning": "eignarfalls",
+			"orð": "embætti",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "92b1ebac5ee8fd9c4260c6879850277348bbbd6d18eca1b21911fdf6fa205d61"
+		},
+		{
+			"orð": "skipti",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"beygingar": ["ft-ág", "ft-mg"],
+			"hash": "245bb58d5c8e5c88f0c3e27827c88715171603fea9276ba5d20dc720b5375be9"
+		}
+	],
+	"ft": {
+		"ág": ["embættaskipti", "embættaskipti", "embættaskiptum", "embættaskipta"],
+		"mg": ["embættaskiptin", "embættaskiptin", "embættaskiptunum", "embættaskiptanna"]
+	},
+	"hash": "1f0b23c7e88c3a74051ef0d19e6429ee1841977a4fe31ea74e1c35323a97099d"
+}

--- a/lokaord/database/data/nafnord/embættistekjur-kvk.json
+++ b/lokaord/database/data/nafnord/embættistekjur-kvk.json
@@ -1,0 +1,27 @@
+{
+	"orð": "embættistekjur",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"samsett": [
+		{
+			"mynd": "embættis",
+			"samsetning": "eignarfalls",
+			"orð": "embætti",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "92b1ebac5ee8fd9c4260c6879850277348bbbd6d18eca1b21911fdf6fa205d61"
+		},
+		{
+			"orð": "tekja",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"beygingar": ["ft-ág", "ft-mg"],
+			"hash": "38ed12dc33793c71ea9d64346e01ebcc9e438aed0c228d8999941e3cb4ab21db"
+		}
+	],
+	"ft": {
+		"ág": ["embættistekjur", "embættistekjur", "embættistekjum", "embættistekna"],
+		"mg": ["embættistekjurnar", "embættistekjurnar", "embættistekjunum", "embættisteknanna"]
+	},
+	"hash": "459024d6a7667221b11222f86928b020602195a0594976f5c1d363aad6bae1e8"
+}

--- a/lokaord/database/data/nafnord/ełlilaun-hk.json
+++ b/lokaord/database/data/nafnord/ełlilaun-hk.json
@@ -1,0 +1,26 @@
+{
+	"orð": "ełlilaun",
+	"flokkur": "nafnorð",
+	"kyn": "hk",
+	"samsett": [
+		{
+			"mynd": "ełli",
+			"samsetning": "stofn",
+			"orð": "ełli",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"hash": "35424b0df4ee7807b21f1c09ed193f9b0144647f3df3d84650aca68543d6ffaf"
+		},
+		{
+			"orð": "laun",
+			"flokkur": "nafnorð",
+			"kyn": "hk",
+			"hash": "954e7d972c12f8c859b61ea283a16f5d525bebc14bfacbcb50542a766aa81e91"
+		}
+	],
+	"ft": {
+		"ág": ["ełlilaun", "ełlilaun", "ełlilaunum", "ełlilauna"],
+		"mg": ["ełlilaunin", "ełlilaunin", "ełlilaununum", "ełlilaunanna"]
+	},
+	"hash": "c55a9a9c662a2edeee84c1707997cb88efdb2b9eb703c12c912574bb971d9cfe"
+}

--- a/lokaord/database/data/nafnord/ełlistyrkur-kk.json
+++ b/lokaord/database/data/nafnord/ełlistyrkur-kk.json
@@ -1,0 +1,30 @@
+{
+	"orð": "ełlistyrkur",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"samsett": [
+		{
+			"mynd": "ełli",
+			"samsetning": "stofn",
+			"orð": "ełli",
+			"flokkur": "nafnorð",
+			"kyn": "kvk",
+			"hash": "35424b0df4ee7807b21f1c09ed193f9b0144647f3df3d84650aca68543d6ffaf"
+		},
+		{
+			"orð": "styrkur",
+			"flokkur": "nafnorð",
+			"kyn": "kk",
+			"hash": "429335e0aa9424a50a5924ea928d6ed36cb4921e09865dd2010b1ce26acf4c6a"
+		}
+	],
+	"et": {
+		"ág": ["ełlistyrkur", "ełlistyrk", "ełlistyrk", "ełlistyrks"],
+		"mg": ["ełlistyrkurinn", "ełlistyrkinn", "ełlistyrknum", "ełlistyrksins"]
+	},
+	"ft": {
+		"ág": ["ełlistyrkir", "ełlistyrki", "ełlistyrkjum", "ełlistyrkja"],
+		"mg": ["ełlistyrkirnir", "ełlistyrkina", "ełlistyrkjunum", "ełlistyrkjanna"]
+	},
+	"hash": "8f9689af2ec40a53e89ab403c07aeadb743754d21ddd347fa03e066baee89689"
+}

--- a/lokaord/database/data/nafnord/kostur-kk.json
+++ b/lokaord/database/data/nafnord/kostur-kk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "kostur",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"et": {
+		"ág": ["kostur", "kost", "kosti", "kosts"],
+		"mg": ["kosturinn", "kostinn", "kostinum", "kostsins"]
+	},
+	"ft": {
+		"ág": ["kostir", "kosti", "kostum", "kosta"],
+		"mg": ["kostirnir", "kostina", "kostunum", "kostanna"]
+	},
+	"hash": "5a2dc5b9fa18d7df9636716c402bf9f0e353b0767faa591fb81ef3904271d68f"
+}

--- a/lokaord/database/data/nafnord/styrkur-kk.json
+++ b/lokaord/database/data/nafnord/styrkur-kk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "styrkur",
+	"flokkur": "nafnorð",
+	"kyn": "kk",
+	"et": {
+		"ág": ["styrkur", "styrk", "styrk", "styrks"],
+		"mg": ["styrkurinn", "styrkinn", "styrknum", "styrksins"]
+	},
+	"ft": {
+		"ág": ["styrkir", "styrki", "styrkjum", "styrkja"],
+		"mg": ["styrkirnir", "styrkina", "styrkjunum", "styrkjanna"]
+	},
+	"hash": "429335e0aa9424a50a5924ea928d6ed36cb4921e09865dd2010b1ce26acf4c6a"
+}

--- a/lokaord/database/data/nafnord/tekja-kvk.json
+++ b/lokaord/database/data/nafnord/tekja-kvk.json
@@ -1,0 +1,14 @@
+{
+	"orð": "tekja",
+	"flokkur": "nafnorð",
+	"kyn": "kvk",
+	"et": {
+		"ág": ["tekja", "tekju", "tekju", "tekju"],
+		"mg": ["tekjan", "tekjuna", "tekjunni", "tekjunnar"]
+	},
+	"ft": {
+		"ág": ["tekjur", "tekjur", "tekjum", "tekna"],
+		"mg": ["tekjurnar", "tekjurnar", "tekjunum", "teknanna"]
+	},
+	"hash": "38ed12dc33793c71ea9d64346e01ebcc9e438aed0c228d8999941e3cb4ab21db"
+}

--- a/lokaord/database/data/sagnord/flytja.json
+++ b/lokaord/database/data/sagnord/flytja.json
@@ -1,0 +1,135 @@
+{
+	"orð": "flytja",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "flytja",
+		"sagnbót": "flutt",
+		"boðháttur": {
+			"stýfður": "flyt",
+			"et": "flyttu",
+			"ft": "flytjið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["flyt", "flytur", "flytur"],
+					"ft": ["flytjum", "flytjið", "flytja"]
+				},
+				"þátíð": {
+					"et": ["flutti", "fluttir", "flutti"],
+					"ft": ["fluttum", "fluttuð", "fluttu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["flytji", "flytjir", "flytji"],
+					"ft": ["flytjum", "flytjið", "flytji"]
+				},
+				"þátíð": {
+					"et": ["flytti", "flyttir", "flytti"],
+					"ft": ["flyttum", "flyttuð", "flyttu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "flyturðu",
+					"ft": "flytjiði"
+				},
+				"þátíð": {
+					"et": "fluttirðu",
+					"ft": "fluttuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "flytjirðu",
+					"ft": "flytjiði"
+				},
+				"þátíð": {
+					"et": "flyttirðu",
+					"ft": "flyttuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "flytjast",
+		"sagnbót": "flust",
+		"boðháttur": {
+			"et": "flystu",
+			"ft": "flytjist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["flyst", "flyst", "flyst"],
+					"ft": ["flytjumst", "flytjist", "flytjast"]
+				},
+				"þátíð": {
+					"et": ["fluttist", "fluttist", "fluttist"],
+					"ft": ["fluttumst", "fluttust", "fluttust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["flytjist", "flytjist", "flytjist"],
+					"ft": ["flytjumst", "flytjist", "flytjist"]
+				},
+				"þátíð": {
+					"et": ["flyttist", "flyttist", "flyttist"],
+					"ft": ["flyttumst", "flyttust", "flyttust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "flystu"
+				},
+				"þátíð": {
+					"et": "fluttistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "flytjistu"
+				},
+				"þátíð": {
+					"et": "flyttistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "flytjandi",
+		"þátíðar": {
+			"sb": {
+				"et": {
+					"kk": ["fluttur", "fluttan", "fluttum", "flutts"],
+					"kvk": ["flutt", "flutta", "fluttri", "fluttrar"],
+					"hk": ["flutt", "flutt", "fluttu", "flutts"]
+				},
+				"ft": {
+					"kk": ["fluttir", "flutta", "fluttum", "fluttra"],
+					"kvk": ["fluttar", "fluttar", "fluttum", "fluttra"],
+					"hk": ["flutt", "flutt", "fluttum", "fluttra"]
+				}
+			},
+			"vb": {
+				"et": {
+					"kk": ["flutti", "flutta", "flutta", "flutta"],
+					"kvk": ["flutta", "fluttu", "fluttu", "fluttu"],
+					"hk": ["flutta", "flutta", "flutta", "flutta"]
+				},
+				"ft": {
+					"kk": ["fluttu", "fluttu", "fluttu", "fluttu"],
+					"kvk": ["fluttu", "fluttu", "fluttu", "fluttu"],
+					"hk": ["fluttu", "fluttu", "fluttu", "fluttu"]
+				}
+			}
+		}
+	},
+	"hash": "af40edc2cef15c6f7a9b51dc375c7b03cc103f2a2f09d33f67e5d9a7ea69eb07"
+}

--- a/lokaord/database/data/sagnord/missa.json
+++ b/lokaord/database/data/sagnord/missa.json
@@ -1,0 +1,128 @@
+{
+	"orð": "missa",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "missa",
+		"sagnbót": "misst",
+		"boðháttur": {
+			"stýfður": "miss",
+			"et": "misstu",
+			"ft": "missið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["missi", "missir", "missir"],
+					"ft": ["missum", "missið", "missa"]
+				},
+				"þátíð": {
+					"et": ["missti", "misstir", "missti"],
+					"ft": ["misstum", "misstuð", "misstu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["missi", "missir", "missi"],
+					"ft": ["missum", "missið", "missi"]
+				},
+				"þátíð": {
+					"et": ["missti", "misstir", "missti"],
+					"ft": ["misstum", "misstuð", "misstu"]
+				}
+			}
+		},
+		"ópersónuleg": {
+			"frumlag": "eignarfall",
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["missir", "missir", "missir"],
+					"ft": ["missir", "missir", "missir"]
+				},
+				"þátíð": {
+					"et": ["missti", "missti", "missti"],
+					"ft": ["missti", "missti", "missti"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["missi", "missi", "missi"],
+					"ft": ["missi", "missi", "missi"]
+				},
+				"þátíð": {
+					"et": ["missti", "missti", "missti"],
+					"ft": ["missti", "missti", "missti"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "missirðu",
+					"ft": "missiði"
+				},
+				"þátíð": {
+					"et": "misstirðu",
+					"ft": "misstuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "missirðu",
+					"ft": "missiði"
+				},
+				"þátíð": {
+					"et": "misstirðu",
+					"ft": "misstuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "missast",
+		"sagnbót": "misst",
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["missist", "missist", "missist"],
+					"ft": ["missumst", "missist", "missast"]
+				},
+				"þátíð": {
+					"et": ["misstist", "misstist", "misstist"],
+					"ft": ["misstumst", "misstust", "misstust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["missist", "missist", "missist"],
+					"ft": ["missumst", "missist", "missist"]
+				},
+				"þátíð": {
+					"et": ["misstist", "misstist", "misstist"],
+					"ft": ["misstumst", "misstust", "misstust"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "missistu"
+				},
+				"þátíð": {
+					"et": "misstistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "missistu"
+				},
+				"þátíð": {
+					"et": "missistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "missandi"
+	},
+	"hash": "e7241daf00239e2fa6df4263566edbb9615646878c19f95f0911cfd88425573c"
+}

--- a/lokaord/database/data/sagnord/mæla-_segja_.json
+++ b/lokaord/database/data/sagnord/mæla-_segja_.json
@@ -1,0 +1,132 @@
+{
+	"orð": "mæla",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "mæla",
+		"sagnbót": "mælt",
+		"boðháttur": {
+			"stýfður": "mæl",
+			"et": "mæltu",
+			"ft": "mælið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mæli", "mælir", "mælir"],
+					"ft": ["mælum", "mælið", "mæla"]
+				},
+				"þátíð": {
+					"et": ["mælti", "mæltir", "mælti"],
+					"ft": ["mæltum", "mæltuð", "mæltu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mæli", "mælir", "mæli"],
+					"ft": ["mælum", "mælið", "mæli"]
+				},
+				"þátíð": {
+					"et": ["mælti", "mæltir", "mælti"],
+					"ft": ["mæltum", "mæltuð", "mæltu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "mælirðu",
+					"ft": "mæliði"
+				},
+				"þátíð": {
+					"et": "mæltirðu",
+					"ft": "mæltuði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "mælirðu",
+					"ft": "mæliði"
+				},
+				"þátíð": {
+					"et": "mæltirðu",
+					"ft": "mæltuði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "mælast",
+		"sagnbót": "mælst",
+		"boðháttur": {
+			"et": "mælistu",
+			"ft": "mælist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælumst", "mælist", "mælast"]
+				},
+				"þátíð": {
+					"et": ["mæltist", "mæltist", "mæltist"],
+					"ft": ["mæltumst", "mæltust", "mæltust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælumst", "mælist", "mælist"]
+				},
+				"þátíð": {
+					"et": ["mæltist", "mæltist", "mæltist"],
+					"ft": ["mæltumst", "mæltust", "mæltust"]
+				}
+			}
+		},
+		"ópersónuleg": {
+			"frumlag": "þágufall",
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælist", "mælist", "mælist"]
+				},
+				"þátíð": {
+					"et": ["mæltist", "mæltist", "mæltist"],
+					"ft": ["mæltist", "mæltist", "mæltist"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælist", "mælist", "mælist"]
+				},
+				"þátíð": {
+					"et": ["mæltist", "mæltist", "mæltist"],
+					"ft": ["mæltist", "mæltist", "mæltist"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "mælistu"
+				},
+				"þátíð": {
+					"et": "mæltistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "mælistu"
+				},
+				"þátíð": {
+					"et": "mæltistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "mælandi"
+	},
+	"hash": "34a057b40cabcd17ac15f17401305d3084a6d7c2e80aa2f96b2f35c13b878d1a"
+}

--- a/lokaord/database/data/sagnord/mæla.json
+++ b/lokaord/database/data/sagnord/mæla.json
@@ -1,0 +1,132 @@
+{
+	"orð": "mæla",
+	"flokkur": "sagnorð",
+	"germynd": {
+		"nafnháttur": "mæla",
+		"sagnbót": "mælt",
+		"boðháttur": {
+			"stýfður": "mæl",
+			"et": "mældu",
+			"ft": "mælið"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mæli", "mælir", "mælir"],
+					"ft": ["mælum", "mælið", "mæla"]
+				},
+				"þátíð": {
+					"et": ["mældi", "mældir", "mældi"],
+					"ft": ["mældum", "mælduð", "mældu"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mæli", "mælir", "mæli"],
+					"ft": ["mælum", "mælið", "mæli"]
+				},
+				"þátíð": {
+					"et": ["mældi", "mældir", "mældi"],
+					"ft": ["mældum", "mælduð", "mældu"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "mælirðu",
+					"ft": "mæliði"
+				},
+				"þátíð": {
+					"et": "mældirðu",
+					"ft": "mælduði"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "mælirðu",
+					"ft": "mæliði"
+				},
+				"þátíð": {
+					"et": "mældirðu",
+					"ft": "mælduði"
+				}
+			}
+		}
+	},
+	"miðmynd": {
+		"nafnháttur": "mælast",
+		"sagnbót": "mælst",
+		"boðháttur": {
+			"et": "mælistu",
+			"ft": "mælist"
+		},
+		"persónuleg": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælumst", "mælist", "mælast"]
+				},
+				"þátíð": {
+					"et": ["mældist", "mældist", "mældist"],
+					"ft": ["mældumst", "mældust", "mældust"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælumst", "mælist", "mælist"]
+				},
+				"þátíð": {
+					"et": ["mældist", "mældist", "mældist"],
+					"ft": ["mældumst", "mældust", "mældust"]
+				}
+			}
+		},
+		"ópersónuleg": {
+			"frumlag": "þágufall",
+			"framsöguháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælist", "mælist", "mælist"]
+				},
+				"þátíð": {
+					"et": ["mældist", "mældist", "mældist"],
+					"ft": ["mældist", "mældist", "mældist"]
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": ["mælist", "mælist", "mælist"],
+					"ft": ["mælist", "mælist", "mælist"]
+				},
+				"þátíð": {
+					"et": ["mældist", "mældist", "mældist"],
+					"ft": ["mældist", "mældist", "mældist"]
+				}
+			}
+		},
+		"spurnarmyndir": {
+			"framsöguháttur": {
+				"nútíð": {
+					"et": "mælistu"
+				},
+				"þátíð": {
+					"et": "mældistu"
+				}
+			},
+			"viðtengingarháttur": {
+				"nútíð": {
+					"et": "mælistu"
+				},
+				"þátíð": {
+					"et": "mældistu"
+				}
+			}
+		}
+	},
+	"lýsingarháttur": {
+		"nútíðar": "mælandi"
+	},
+	"hash": "2ca01f2ae692585851f6c15b2e4fa1e4a068dc5cf9fbe26950c7b3afa0846a81"
+}

--- a/lokaord/seer.py
+++ b/lokaord/seer.py
@@ -50,6 +50,8 @@ def scan_sentence(sentence):
     maybe = 0
     missing = 0
     for word in sentence.split(' '):
+        if word == '':
+            continue
         scanned_word = {
             'orð': word,
             'orð-hreinsað': None,


### PR DESCRIPTION
bæta við orðum úr einni málsgrein 20. greinar núgildandi stjórnarskrár

`lokaord -ss "Forseti getur flutt embættismenn úr einu embætti í annað, enda missi þeir einskis í af embættistekjum sínum, og sé þeim veittur kostur á að kjósa um embættaskiptin eða lausn frá embætti með lögmæltum eftirlaunum eða lögmæltum ellistyrk."`

sjá issue #20 